### PR TITLE
Fix pip path in project pelias.json files

### DIFF
--- a/projects/france/pelias.json
+++ b/projects/france/pelias.json
@@ -20,7 +20,7 @@
   "api": {
     "textAnalyzer": "libpostal",
     "services": {
-      "pip": { "url": "http://pip-service:4200" },
+      "pip": { "url": "http://pip:4200" },
       "libpostal": { "url": "http://libpostal:8080" },
       "placeholder": { "url": "http://placeholder:4100" },
       "interpolation": { "url": "http://interpolation:4300" }

--- a/projects/los-angeles-metro/pelias.json
+++ b/projects/los-angeles-metro/pelias.json
@@ -25,7 +25,7 @@
   "api": {
     "textAnalyzer": "libpostal",
     "services": {
-      "pip": { "url": "http://pip-service:4200" },
+      "pip": { "url": "http://pip:4200" },
       "libpostal": { "url": "http://libpostal:8080" },
       "placeholder": { "url": "http://placeholder:4100" },
       "interpolation": { "url": "http://interpolation:4300" }

--- a/projects/portland-metro/pelias.json
+++ b/projects/portland-metro/pelias.json
@@ -25,7 +25,7 @@
   "api": {
     "textAnalyzer": "libpostal",
     "services": {
-      "pip": { "url": "http://pip-service:4200" },
+      "pip": { "url": "http://pip:4200" },
       "libpostal": { "url": "http://libpostal:8080" },
       "placeholder": { "url": "http://placeholder:4100" },
       "interpolation": { "url": "http://interpolation:4300" }

--- a/projects/south-africa/pelias.json
+++ b/projects/south-africa/pelias.json
@@ -25,7 +25,7 @@
   "api": {
     "textAnalyzer": "libpostal",
     "services": {
-      "pip": { "url": "http://pip-service:4200" },
+      "pip": { "url": "http://pip:4200" },
       "libpostal": { "url": "http://libpostal:8080" },
       "placeholder": { "url": "http://placeholder:4100" },
       "interpolation": { "url": "http://interpolation:4300" }


### PR DESCRIPTION
The url to the pip service in the example projects pelias.json config files was `http://pip-service:4200`. In the docker-compose.yml files, the name of the service is `pip` (not `pip-service`).

This PR changes `api.services.pip.url` to `http://pip:4200`.
Fixes #7 