### PR TITLE
Avoid using NPM in scripts

### DIFF
--- a/cmd/elastic.sh
+++ b/cmd/elastic.sh
@@ -2,7 +2,7 @@
 set -e;
 
 function elastic_schema_drop(){ compose_run 'schema' node scripts/drop_index "$@" || true; }
-function elastic_schema_create(){ compose_run 'schema' npm run create_index; }
+function elastic_schema_create(){ compose_run 'schema' node scripts/create_index; }
 function elastic_start(){ compose_exec up -d elasticsearch; }
 function elastic_stop(){ compose_exec kill elasticsearch; }
 

--- a/cmd/prepare.sh
+++ b/cmd/prepare.sh
@@ -5,8 +5,8 @@ set -e;
 function prepare_polylines(){ compose_run 'polylines' bash ./docker_extract.sh; }
 function prepare_interpolation(){ compose_run 'interpolation' bash ./docker_build.sh; }
 function prepare_placeholder(){
-  compose_run 'placeholder' npm run extract
-  compose_run 'placeholder' npm run build
+  compose_run 'placeholder' ./cmd/extract.sh;
+  compose_run 'placeholder' ./cmd/build.sh;
 }
 
 register 'prepare' 'polylines' 'export road network from openstreetmap into polylines format' prepare_polylines


### PR DESCRIPTION
NPM creates an extra layer of processes in containers which [do not properly forward signals](https://github.com/npm/npm/issues/4603). This
can cause problems starting/stopping containers quickly.

Additionally NPM tries to write to the filesystem as part of its self-update check. We would like to move to read only root container filesystems (using `read_only: true` in docker-compose.yml), so the easiest way to work around this NPM "feature" is to avoid using NPM.