### PR TITLE
Remove out of date libpostal settings

### DIFF
--- a/projects/france/docker-compose.yml
+++ b/projects/france/docker-compose.yml
@@ -3,12 +3,7 @@ networks:
   default:
     driver: bridge
 volumes:
-  libpostaldata:
-    driver: local
 services:
-  libpostal_baseimage:
-    image: pelias/libpostal_baseimage
-    container_name: pelias_libpostal_baseimage
   libpostal:
     image: pelias/go-whosonfirst-libpostal
     container_name: pelias_libpostal
@@ -27,7 +22,6 @@ services:
     ports: [ "4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
-      - "libpostaldata:/usr/share/libpostal"
   placeholder:
     image: pelias/placeholder:master
     container_name: pelias_placeholder
@@ -62,7 +56,6 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   interpolation:
-    depends_on: [ "libpostal_baseimage" ]
     image: pelias/interpolation:master
     container_name: pelias_interpolation
     restart: always
@@ -70,7 +63,6 @@ services:
     ports: [ "4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
-      - "libpostaldata:/usr/share/libpostal"
       - "${DATA_DIR}:/data"
   pip:
     image: pelias/pip-service:master

--- a/projects/los-angeles-metro/docker-compose.yml
+++ b/projects/los-angeles-metro/docker-compose.yml
@@ -3,12 +3,7 @@ networks:
   default:
     driver: bridge
 volumes:
-  libpostaldata:
-    driver: local
 services:
-  libpostal_baseimage:
-    image: pelias/libpostal_baseimage
-    container_name: pelias_libpostal_baseimage
   libpostal:
     image: pelias/go-whosonfirst-libpostal
     container_name: pelias_libpostal
@@ -29,7 +24,6 @@ services:
     ports: [ "4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
-      - "libpostaldata:/usr/share/libpostal"
   placeholder:
     image: pelias/placeholder:master
     container_name: pelias_placeholder
@@ -70,7 +64,6 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   interpolation:
-    depends_on: [ "libpostal_baseimage" ]
     image: pelias/interpolation:master
     container_name: pelias_interpolation
     restart: always
@@ -78,7 +71,6 @@ services:
     ports: [ "4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
-      - "libpostaldata:/usr/share/libpostal"
       - "${DATA_DIR}:/data"
   pip:
     image: pelias/pip-service:master

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -2,13 +2,7 @@ version: '3'
 networks:
   default:
     driver: bridge
-volumes:
-  libpostaldata:
-    driver: local
 services:
-  libpostal_baseimage:
-    image: pelias/libpostal_baseimage
-    container_name: pelias_libpostal_baseimage
   libpostal:
     image: pelias/go-whosonfirst-libpostal
     container_name: pelias_libpostal
@@ -29,7 +23,6 @@ services:
     ports: [ "4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
-      - "libpostaldata:/usr/share/libpostal"
   placeholder:
     image: pelias/placeholder:master
     container_name: pelias_placeholder
@@ -70,7 +63,6 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   interpolation:
-    depends_on: [ "libpostal_baseimage" ]
     image: pelias/interpolation:master
     container_name: pelias_interpolation
     restart: always
@@ -78,7 +70,6 @@ services:
     ports: [ "4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
-      - "libpostaldata:/usr/share/libpostal"
       - "${DATA_DIR}:/data"
   pip:
     image: pelias/pip-service:master

--- a/projects/south-africa/docker-compose.yml
+++ b/projects/south-africa/docker-compose.yml
@@ -3,12 +3,7 @@ networks:
   default:
     driver: bridge
 volumes:
-  libpostaldata:
-    driver: local
 services:
-  libpostal_baseimage:
-    image: pelias/libpostal_baseimage
-    container_name: pelias_libpostal_baseimage
   libpostal:
     image: pelias/go-whosonfirst-libpostal
     container_name: pelias_libpostal
@@ -29,7 +24,6 @@ services:
     ports: [ "4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
-      - "libpostaldata:/usr/share/libpostal"
   placeholder:
     image: pelias/placeholder:master
     container_name: pelias_placeholder
@@ -71,7 +65,6 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   interpolation:
-    depends_on: [ "libpostal_baseimage" ]
     image: pelias/interpolation:master
     container_name: pelias_interpolation
     restart: always
@@ -79,7 +72,6 @@ services:
     ports: [ "4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
-      - "libpostaldata:/usr/share/libpostal"
       - "${DATA_DIR}:/data"
   pip:
     image: pelias/pip-service:master


### PR DESCRIPTION
We have some settings in our docker-compose.yml files that are from when we did things quite differently.

Previously, we built the libpostal_baseimage image directly as part of
our Docker setup projects. This required setting it as a "dependency" of
other images. That's no longer required, and having that `dependency`
setting is causing an extra container to be launched, after which it
does nothing and shuts down.

Additionaly, we used to store libpostal training data in a separate
filesystem. It's now baked into the `libpostal_baseimage` image, so all
those settings are no longer required.