### PR TITLE
feat(debug-proxy): add http debug proxy image

### DIFF
--- a/images/debug-proxy/Dockerfile
+++ b/images/debug-proxy/Dockerfile
@@ -1,0 +1,3 @@
+FROM node:0.12
+ADD script.js /script.js
+CMD ["node", "/script.js"]

--- a/images/debug-proxy/README.md
+++ b/images/debug-proxy/README.md
@@ -1,0 +1,24 @@
+
+HTTP debugging proxy
+
+## Usage
+
+```yaml
+  debugproxy:
+    image: pelias/debug-proxy:latest
+    container_name: debugproxy
+    restart: always
+    environment: [ "HOST=placeholder", "PORT=4100" ]
+    ports: [ "8000:8000" ]
+```
+
+## Rebuild image
+
+```bash
+docker build -t pelias/debug-proxy .
+```
+
+## Credit
+
+Source code copied from:
+https://github.com/acroca/http-docker-debug-proxy

--- a/images/debug-proxy/script.js
+++ b/images/debug-proxy/script.js
@@ -1,0 +1,36 @@
+var net = require("net");
+
+// copied from https://github.com/acroca/http-docker-debug-proxy
+// credit: https://github.com/acroca
+
+var host = process.env["HOST"];
+var port = process.env["PORT"];
+var bindPort = process.env["BIND"] || 8000;
+
+proxy = net.createServer(function(socket){
+  var client;
+  console.log('**** Client connected to proxy');
+
+  client = net.connect({port: port, host: host});
+
+  clientToServer = socket.pipe(client)
+  serverToClient = clientToServer.pipe(socket);
+
+  socket.on('close', function () {
+      console.log('**** Client disconnected from proxy');
+  });
+  socket.on('error', function (err) {
+      console.log('Error: ' + err.soString());
+  });
+
+  socket.on('data', function(d) {
+    var s = d.toString()
+    console.log("=> " + s.replace(/\n/g, "\n=> "))
+  })
+  clientToServer.on('data', function(d) {
+    var s = d.toString()
+    console.log("<= " + s.replace(/\n/g, "\n<= "))
+  })
+
+})
+proxy.listen(bindPort)


### PR DESCRIPTION
This adds an HTTP debug proxy image which was useful in testing https://github.com/pelias/api/pull/1188

Here's an example of how I used it to inspect the HTTP traffic between `api` and `placeholder`:

```diff
diff --git a/projects/portland-metro/docker-compose.yml b/projects/portland-metro/docker-compose.yml
index d2e3a8c..15a31bf 100644
--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -8,6 +8,12 @@ services:
     container_name: pelias_libpostal
     restart: always
     ports: [ "8080:8080" ]
+  debugproxy:
+    image: pelias/debug-proxy
+    container_name: debugproxy
+    restart: always
+    environment: [ "HOST=placeholder", "PORT=4100" ]
+    ports: [ "8000:8000" ]
   schema:
     image: pelias/schema:portland-synonyms
     container_name: pelias_schema
@@ -16,7 +22,7 @@ services:
       - "./synonyms/custom_name.txt:/code/pelias/schema/synonyms/custom_name.txt"
       - "./synonyms/custom_street.txt:/code/pelias/schema/synonyms/custom_street.txt"
   api:
-    image: pelias/api:master
+    image: pelias/api:joxit-placeholder-lang-param
     container_name: pelias_api
     restart: always
     environment: [ "PORT=4000" ]

diff --git a/projects/portland-metro/pelias.json b/projects/portland-metro/pelias.json
index be76592..7e1e126 100644
--- a/projects/portland-metro/pelias.json
+++ b/projects/portland-metro/pelias.json
@@ -27,7 +27,7 @@
     "services": {
       "pip": { "url": "http://pip:4200" },
       "libpostal": { "url": "http://libpostal:8080" },
-      "placeholder": { "url": "http://placeholder:4100" },
+      "placeholder": { "url": "http://debugproxy:8000" },
       "interpolation": { "url": "http://interpolation:4300" }
     },
     "defaultParameters": {
```

live HTTP logs can be viewed as such:

```bash
pelias compose logs -f debugproxy

Attaching to debugproxy

debugproxy          | **** Client connected to proxy
debugproxy          | => GET /parser/findbyid?ids=85893153%2C85688513%2C102081631%2C101715829%2C102191575%2C85633793&lang=eng HTTP/1.1
debugproxy          | => Host: debugproxy:8000
debugproxy          | => Accept-Encoding: gzip, deflate
debugproxy          | => User-Agent: node-superagent/3.8.3
debugproxy          | => dnt: 1
debugproxy          | => Accept: application/json
debugproxy          | => Connection: keep-alive
debugproxy          | => 
debugproxy          | => 
debugproxy          | <= HTTP/1.1 200 OK
debugproxy          | <= X-Powered-By: Express
debugproxy          | <= Charset: utf8
debugproxy          | <= Cache-Control: public, max-age=120
debugproxy          | <= Content-Type: application/json; charset=utf-8
debugproxy          | <= Content-Length: 2224
debugproxy          | <= ETag: W/"8b0-TwKhNTtWvsovx7kSBHUNOuRssQM"
debugproxy          | <= Date: Thu, 06 Sep 2018 10:05:21 GMT
debugproxy          | <= Connection: keep-alive
debugproxy          | <= 
debugproxy          | <= {"85633793":{"id":85633793,"name":"United States","abbr":"USA","placetype":"country","rank":{"min":19,"max":20},"population":318697314,"lineage":[{"continent_id":102191575,"country_id":85633793,"empire_id":136253057}],"geom":{"area":1166.187278,"bbox":"-124.848973,24.396308,-66.885444,49.384358","lat":39.715956,"lon":-96.999668},"names":{"eng":["United States"]}},"85688513":{"id":85688513,"name":"Oregon","abbr":"OR","placetype":"region","rank":{"min":14,"max":15},"population":3831074,"lineage":[{"continent_id":102191575,"country_id":85633793,"region_id":85688513}],"geom":{"area":28.568535,"bbox":"-124.703541,41.991794,-116.463262,46.299099","lat":43.854178,"lon":-120.526709},"names":{"eng":["Oregon"]}},"85893153":{"id":85893153,"name":"Argay","placetype":"neighbourhood","rank":{"min":5,"max":6},"population":3284,"popularity":126,"lineage":[{"continent_id":102191575,"country_id":85633793,"county_id":102081631,"locality_id":101715829,"macrohood_id":1108720843,"neighbourhood_id":85893153,"region_id":85688513}],"geom":{"area":0.000565,"bbox":"-122.537942717,45.5428044244,-122.509958652,45.5679592422","lat":45.552706,"lon":-122.524145},"names":{"eng":["Argay"]}},"101715829":{"id":101715829,"name":"Portland","placetype":"locality","rank":{"min":9,"max":10},"population":583776,"lineage":[{"continent_id":102191575,"country_id":85633793,"county_id":102081631,"locality_id":101715829,"region_id":85688513}],"geom":{"area":0.04329,"bbox":"-122.83675,45.432393,-122.472021,45.653272","lat":45.533467,"lon":-122.650095},"names":{"eng":["Portland"]}},"102081631":{"id":102081631,"name":"Multnomah County","placetype":"county","rank":{"min":12,"max":13},"population":735334,"lineage":[{"continent_id":102191575,"country_id":85633793,"county_id":102081631,"region_id":85688513}],"geom":{"area":0.138938,"bbox":"-122.929226,45.432712,-121.820394,45.728687","lat":45.534259,"lon":-122.600162},"names":{"eng":["Multnomah County"]}},"102191575":{"id":102191575,"name":"North America","placetype":"continent","rank":{"min":21,"max":22},"lineage":[{"continent_id":102191575}],"geom":{"area":3704.177719,"bbox":"-179.143503,5.515082,179.780935,83.634101","lat":38.309137,"lon":-101.328273},"names":{"eng":["North America"]}}}

...
```