### PR TITLE
Add example of using blacklist functionality

### DIFF
--- a/projects/portland-metro/blacklist/osm.txt
+++ b/projects/portland-metro/blacklist/osm.txt
@@ -1,0 +1,1 @@
+openstreetmap:venue:way:59581827 # remove the problematic portland airport record

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -38,18 +38,21 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
+      - "./blacklist/:/data/blacklist"
   openstreetmap:
     image: pelias/openstreetmap:master
     container_name: pelias_openstreetmap
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
+      - "./blacklist/:/data/blacklist"
   openaddresses:
     image: pelias/openaddresses:master
     container_name: pelias_openaddresses
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
+      - "./blacklist/:/data/blacklist"
   transit:
     image: pelias/transit:master
     container_name: pelias_transit

--- a/projects/portland-metro/pelias.json
+++ b/projects/portland-metro/pelias.json
@@ -39,6 +39,11 @@
     "adminLookup": {
       "enabled": true
     },
+    "blacklist": {
+      "files": [
+        "/data/blacklist/osm.txt"
+      ]
+    },
     "geonames": {
       "datapath": "/data/geonames",
       "countryCode": "ALL"


### PR DESCRIPTION
This removes the problematic PDX record from OSM (which has a centroid
that is unhelpful for routing, with no clear way to fix).