### PR TITLE
Remove document service

### DIFF
--- a/projects/france/docker-compose.yml
+++ b/projects/france/docker-compose.yml
@@ -73,14 +73,6 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
-  document-service:
-    image: pelias/document-service:master
-    container_name: pelias_document-service
-    restart: always
-    ports: [ "5000:5000" ]
-    volumes:
-      - "./pelias.json:/code/pelias.json"
-      - "${DATA_DIR}:/data"
   elasticsearch:
     image: pelias/elasticsearch
     container_name: pelias_elasticsearch

--- a/projects/los-angeles-metro/docker-compose.yml
+++ b/projects/los-angeles-metro/docker-compose.yml
@@ -81,14 +81,6 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
-  document-service:
-    image: pelias/document-service:master
-    container_name: pelias_document-service
-    restart: always
-    ports: [ "5000:5000" ]
-    volumes:
-      - "./pelias.json:/code/pelias.json"
-      - "${DATA_DIR}:/data"
   elasticsearch:
     image: pelias/elasticsearch
     container_name: pelias_elasticsearch

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -80,14 +80,6 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
-  document-service:
-    image: pelias/document-service:master
-    container_name: pelias_document-service
-    restart: always
-    ports: [ "5000:5000" ]
-    volumes:
-      - "./pelias.json:/code/pelias.json"
-      - "${DATA_DIR}:/data"
   elasticsearch:
     image: pelias/elasticsearch
     container_name: pelias_elasticsearch

--- a/projects/south-africa/docker-compose.yml
+++ b/projects/south-africa/docker-compose.yml
@@ -82,14 +82,6 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
-  document-service:
-    image: pelias/document-service:master
-    container_name: pelias_document-service
-    restart: always
-    ports: [ "5000:5000" ]
-    volumes:
-      - "./pelias.json:/code/pelias.json"
-      - "${DATA_DIR}:/data"
   preview:
     image: nginx
     container_name: pelias_preview


### PR DESCRIPTION
The document service originally became part of this repository because it was used in a Mapzen demo/workshop some time ago as a more convenient way to index documents for custom importers.

While it could be useful, it isn't currently supported and is not used in this repository. By removing it from all the docker-compose.yml files, we can reduce the size of downloaded Docker images.