### PR TITLE
Use new pelias/libpostal-service Docker image

### DIFF
--- a/projects/france/docker-compose.yml
+++ b/projects/france/docker-compose.yml
@@ -5,10 +5,10 @@ networks:
 volumes:
 services:
   libpostal:
-    image: pelias/go-whosonfirst-libpostal
+    image: pelias/libpostal-service
     container_name: pelias_libpostal
     restart: always
-    ports: [ "8080:8080" ]
+    ports: [ "4400:4400" ]
   schema:
     image: pelias/schema:portland-synonyms
     container_name: pelias_schema

--- a/projects/france/pelias.json
+++ b/projects/france/pelias.json
@@ -21,7 +21,7 @@
     "textAnalyzer": "libpostal",
     "services": {
       "pip": { "url": "http://pip:4200" },
-      "libpostal": { "url": "http://libpostal:8080" },
+      "libpostal": { "url": "http://libpostal:4400" },
       "placeholder": { "url": "http://placeholder:4100" },
       "interpolation": { "url": "http://interpolation:4300" }
     },

--- a/projects/los-angeles-metro/docker-compose.yml
+++ b/projects/los-angeles-metro/docker-compose.yml
@@ -5,10 +5,10 @@ networks:
 volumes:
 services:
   libpostal:
-    image: pelias/go-whosonfirst-libpostal
+    image: pelias/libpostal-service
     container_name: pelias_libpostal
     restart: always
-    ports: [ "8080:8080" ]
+    ports: [ "4400:4400" ]
   schema:
     image: pelias/schema:portland-synonyms
     container_name: pelias_schema

--- a/projects/los-angeles-metro/pelias.json
+++ b/projects/los-angeles-metro/pelias.json
@@ -26,7 +26,7 @@
     "textAnalyzer": "libpostal",
     "services": {
       "pip": { "url": "http://pip:4200" },
-      "libpostal": { "url": "http://libpostal:8080" },
+      "libpostal": { "url": "http://libpostal:4400" },
       "placeholder": { "url": "http://placeholder:4100" },
       "interpolation": { "url": "http://interpolation:4300" }
     },

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -4,10 +4,10 @@ networks:
     driver: bridge
 services:
   libpostal:
-    image: pelias/go-whosonfirst-libpostal
+    image: pelias/libpostal-service
     container_name: pelias_libpostal
     restart: always
-    ports: [ "8080:8080" ]
+    ports: [ "4400:4400" ]
   schema:
     image: pelias/schema:portland-synonyms
     container_name: pelias_schema

--- a/projects/portland-metro/pelias.json
+++ b/projects/portland-metro/pelias.json
@@ -25,10 +25,10 @@
   "api": {
     "textAnalyzer": "libpostal",
     "services": {
-      "pip": { "url": "http://pip:4200" },
-      "libpostal": { "url": "http://libpostal:8080" },
       "placeholder": { "url": "http://placeholder:4100" },
-      "interpolation": { "url": "http://interpolation:4300" }
+      "pip": { "url": "http://pip:4200" },
+      "interpolation": { "url": "http://interpolation:4300" },
+      "libpostal": { "url": "http://libpostal:4400" }
     },
     "defaultParameters": {
       "focus.point.lat": 45.52,

--- a/projects/south-africa/docker-compose.yml
+++ b/projects/south-africa/docker-compose.yml
@@ -5,10 +5,10 @@ networks:
 volumes:
 services:
   libpostal:
-    image: pelias/go-whosonfirst-libpostal
+    image: pelias/libpostal-service
     container_name: pelias_libpostal
     restart: always
-    ports: [ "8080:8080" ]
+    ports: [ "4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema

--- a/projects/south-africa/pelias.json
+++ b/projects/south-africa/pelias.json
@@ -26,7 +26,7 @@
     "textAnalyzer": "libpostal",
     "services": {
       "pip": { "url": "http://pip:4200" },
-      "libpostal": { "url": "http://libpostal:8080" },
+      "libpostal": { "url": "http://libpostal:4400" },
       "placeholder": { "url": "http://placeholder:4100" },
       "interpolation": { "url": "http://interpolation:4300" }
     }


### PR DESCRIPTION
This image, from [pelias/libpostal-service](https://github.com/pelias/libpostal-service) gives us a bit more control and consistency over how the libpostal-service is run.

Benefits include:
- smaller download footprint since it shares the pelias/libpostal_baseimage download with the interpolation service
- non-root `pelias` user and other features common to pelias/baseimage
- default port number consistent with other Pelias services