### PR TITLE
Allow configuring container process UID

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Then use your text editor to modify the `.env` file to reflect your new path, it
 ```bash
 COMPOSE_PROJECT_NAME=pelias
 DATA_DIR=/tmp/pelias
+DOCKER_USER=1000
 ```
 
 You can then list the environment variables to ensure they have been correctly set:
@@ -94,6 +95,12 @@ pelias system env
 The compose variables are optional and are documented here: https://docs.docker.com/compose/env-file/
 
 Note: changing the `COMPOSE_PROJECT_NAME` variable is not advisable unless you know what you are doing. If you are migrating from the deprecated `pelias/dockerfiles` repository then you can set `COMPOSE_PROJECT_NAME=dockerfiles` to enable backwards compatibility with containers created using that repository.
+
+### Variable: DOCKER_USER
+
+All processes in Pelias containers are run as non-root users. By default, the UID of the processes will be `1000`, which is the first user ID on _most_ Linux systems and is likely to be a good option. However, if restricting file permissions in your data directory to a different user or group is important, this can be overridden by setting the `DOCKER_USER` variable.
+
+This variable can take just a UID or a UID:GID combination such as `1000:1000`. See the [docker-compose](https://docs.docker.com/compose/compose-file/#domainname-hostname-ipc-mac_address-privileged-read_only-shm_size-stdin_open-tty-user-working_dir) and [docker run](https://docs.docker.com/engine/reference/run/#user) documentation on controlling Docker container users for more information.
 
 ## CLI commands
 

--- a/projects/france/.env
+++ b/projects/france/.env
@@ -1,2 +1,3 @@
 COMPOSE_PROJECT_NAME=pelias
 DATA_DIR=/tmp/pelias/france
+DOCKER_USER=1000

--- a/projects/france/docker-compose.yml
+++ b/projects/france/docker-compose.yml
@@ -2,21 +2,23 @@ version: '3'
 networks:
   default:
     driver: bridge
-volumes:
 services:
   libpostal:
     image: pelias/libpostal-service
     container_name: pelias_libpostal
+    user: "${DOCKER_USER}"
     restart: always
     ports: [ "4400:4400" ]
   schema:
     image: pelias/schema:portland-synonyms
     container_name: pelias_schema
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
   api:
     image: pelias/api:master
     container_name: pelias_api
+    user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
     ports: [ "4000:4000" ]
@@ -25,6 +27,7 @@ services:
   placeholder:
     image: pelias/placeholder:master
     container_name: pelias_placeholder
+    user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
     ports: [ "4100:4100" ]
@@ -34,30 +37,35 @@ services:
   whosonfirst:
     image: pelias/whosonfirst:master
     container_name: pelias_whosonfirst
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   openstreetmap:
     image: pelias/openstreetmap:master
     container_name: pelias_openstreetmap
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   openaddresses:
     image: pelias/openaddresses:master
     container_name: pelias_openaddresses
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   polylines:
     image: pelias/polylines:master
     container_name: pelias_polylines
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   interpolation:
     image: pelias/interpolation:master
     container_name: pelias_interpolation
+    user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
     ports: [ "4300:4300" ]
@@ -67,6 +75,7 @@ services:
   pip:
     image: pelias/pip-service:master
     container_name: pelias_pip-service
+    user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
     ports: [ "4200:4200" ]

--- a/projects/los-angeles-metro/.env
+++ b/projects/los-angeles-metro/.env
@@ -1,2 +1,3 @@
 COMPOSE_PROJECT_NAME=pelias
 DATA_DIR=/tmp/pelias/los-angeles-metro
+DOCKER_USER=1000

--- a/projects/los-angeles-metro/docker-compose.yml
+++ b/projects/los-angeles-metro/docker-compose.yml
@@ -2,16 +2,17 @@ version: '3'
 networks:
   default:
     driver: bridge
-volumes:
 services:
   libpostal:
     image: pelias/libpostal-service
     container_name: pelias_libpostal
+    user: "${DOCKER_USER}"
     restart: always
     ports: [ "4400:4400" ]
   schema:
     image: pelias/schema:portland-synonyms
     container_name: pelias_schema
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "./synonyms/custom_name.txt:/code/pelias/schema/synonyms/custom_name.txt"
@@ -19,6 +20,7 @@ services:
   api:
     image: pelias/api:master
     container_name: pelias_api
+    user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
     ports: [ "4000:4000" ]
@@ -27,6 +29,7 @@ services:
   placeholder:
     image: pelias/placeholder:master
     container_name: pelias_placeholder
+    user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
     ports: [ "4100:4100" ]
@@ -36,36 +39,42 @@ services:
   whosonfirst:
     image: pelias/whosonfirst:master
     container_name: pelias_whosonfirst
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   openstreetmap:
     image: pelias/openstreetmap:master
     container_name: pelias_openstreetmap
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   openaddresses:
     image: pelias/openaddresses:master
     container_name: pelias_openaddresses
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   transit:
     image: pelias/transit:master
     container_name: pelias_transit
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   polylines:
     image: pelias/polylines:master
     container_name: pelias_polylines
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   interpolation:
     image: pelias/interpolation:master
     container_name: pelias_interpolation
+    user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
     ports: [ "4300:4300" ]
@@ -75,6 +84,7 @@ services:
   pip:
     image: pelias/pip-service:master
     container_name: pelias_pip-service
+    user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
     ports: [ "4200:4200" ]
@@ -99,6 +109,7 @@ services:
   fuzzy-tester:
     image: pelias/fuzzy-tester:master
     container_name: pelias_fuzzy_tester
+    user: "${DOCKER_USER}"
     restart: "no"
     command: "--help"
     volumes:

--- a/projects/portland-metro/.env
+++ b/projects/portland-metro/.env
@@ -1,2 +1,3 @@
 COMPOSE_PROJECT_NAME=pelias
 DATA_DIR=/tmp/pelias/portland-metro
+DOCKER_USER=1000

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -6,11 +6,13 @@ services:
   libpostal:
     image: pelias/libpostal-service
     container_name: pelias_libpostal
+    user: "${DOCKER_USER}"
     restart: always
     ports: [ "4400:4400" ]
   schema:
     image: pelias/schema:portland-synonyms
     container_name: pelias_schema
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "./synonyms/custom_name.txt:/code/pelias/schema/synonyms/custom_name.txt"
@@ -18,6 +20,7 @@ services:
   api:
     image: pelias/api:master
     container_name: pelias_api
+    user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
     ports: [ "4000:4000" ]
@@ -26,6 +29,7 @@ services:
   placeholder:
     image: pelias/placeholder:master
     container_name: pelias_placeholder
+    user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
     ports: [ "4100:4100" ]
@@ -35,6 +39,7 @@ services:
   whosonfirst:
     image: pelias/whosonfirst:master
     container_name: pelias_whosonfirst
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -42,6 +47,7 @@ services:
   openstreetmap:
     image: pelias/openstreetmap:master
     container_name: pelias_openstreetmap
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -49,6 +55,7 @@ services:
   openaddresses:
     image: pelias/openaddresses:master
     container_name: pelias_openaddresses
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -56,18 +63,21 @@ services:
   transit:
     image: pelias/transit:master
     container_name: pelias_transit
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   polylines:
     image: pelias/polylines:master
     container_name: pelias_polylines
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   interpolation:
     image: pelias/interpolation:master
     container_name: pelias_interpolation
+    user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
     ports: [ "4300:4300" ]
@@ -77,6 +87,7 @@ services:
   pip:
     image: pelias/pip-service:master
     container_name: pelias_pip-service
+    user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
     ports: [ "4200:4200" ]
@@ -101,6 +112,7 @@ services:
   fuzzy-tester:
     image: pelias/fuzzy-tester:master
     container_name: pelias_fuzzy_tester
+    user: "${DOCKER_USER}"
     restart: "no"
     command: "--help"
     volumes:

--- a/projects/south-africa/.env
+++ b/projects/south-africa/.env
@@ -1,2 +1,3 @@
 COMPOSE_PROJECT_NAME=pelias_za
 DATA_DIR=/tmp/pelias/pelias_za
+DOCKER_USER=1000

--- a/projects/south-africa/docker-compose.yml
+++ b/projects/south-africa/docker-compose.yml
@@ -2,16 +2,17 @@ version: '3'
 networks:
   default:
     driver: bridge
-volumes:
 services:
   libpostal:
     image: pelias/libpostal-service
     container_name: pelias_libpostal
+    user: "${DOCKER_USER}"
     restart: always
     ports: [ "4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "./synonyms/custom_name.txt:/code/pelias/schema/synonyms/custom_name.txt"
@@ -19,6 +20,7 @@ services:
   api:
     image: pelias/api:master
     container_name: pelias_api
+    user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
     ports: [ "4000:4000" ]
@@ -27,6 +29,7 @@ services:
   placeholder:
     image: pelias/placeholder:master
     container_name: pelias_placeholder
+    user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
     ports: [ "4100:4100" ]
@@ -36,12 +39,14 @@ services:
   whosonfirst:
     image: pelias/whosonfirst:master
     container_name: pelias_whosonfirst
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   openstreetmap:
     image: pelias/openstreetmap:master
     container_name: pelias_openstreetmap
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -49,24 +54,28 @@ services:
   openaddresses:
     image: pelias/openaddresses:master
     container_name: pelias_openaddresses
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   transit:
     image: pelias/transit:master
     container_name: pelias_transit
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   polylines:
     image: pelias/polylines:master
     container_name: pelias_polylines
+    user: "${DOCKER_USER}"
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   interpolation:
     image: pelias/interpolation:master
     container_name: pelias_interpolation
+    user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
     ports: [ "4300:4300" ]
@@ -76,6 +85,7 @@ services:
   pip:
     image: pelias/pip-service:master
     container_name: pelias_pip-service
+    user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
     ports: [ "4200:4200" ]
@@ -107,6 +117,7 @@ services:
   fuzzy-tester:
     image: pelias/fuzzy-tester:master
     container_name: pelias_fuzzy_tester
+    user: "${DOCKER_USER}"
     restart: "no"
     command: "--help"
     volumes:


### PR DESCRIPTION
By default, all Pelias images now have a user called `pelias` with UID 1000. However, running as a different UID may be best for different people, depending on their system setup.

By setting the default in `.env` and using it in `docker-compose.yml`, we can allow people running Pelias to use whatever non-root user is best for them.

Connects https://github.com/pelias/baseimage/pull/2