### PR TITLE
Remove all calls to npm in `pelias` binary

### DIFF
--- a/cmd/download.sh
+++ b/cmd/download.sh
@@ -2,11 +2,11 @@
 set -e;
 
 # per-source downloads
-function download_wof(){ compose_run 'whosonfirst' npm run download; }
-function download_oa(){ compose_run 'openaddresses' npm run download; }
-function download_osm(){ compose_run 'openstreetmap' npm run download; }
-function download_tiger(){ compose_run 'interpolation' npm run download-tiger; }
-function download_transit(){ compose_run 'transit' npm run download; }
+function download_wof(){ compose_run 'whosonfirst' './bin/download'; }
+function download_oa(){ compose_run 'openaddresses' './bin/download'; }
+function download_osm(){ compose_run 'openstreetmap' './bin/download'; }
+function download_tiger(){ compose_run 'interpolation' './bin/download-tiger'; }
+function download_transit(){ compose_run 'transit' './bin/download'; }
 
 register 'download' 'wof' '(re)download whosonfirst data' download_wof
 register 'download' 'oa' '(re)download openaddresses data' download_oa

--- a/cmd/import.sh
+++ b/cmd/import.sh
@@ -2,11 +2,11 @@
 set -e;
 
 # per-source imports
-function import_wof(){ compose_run 'whosonfirst' npm start; }
-function import_oa(){ compose_run 'openaddresses' npm start; }
-function import_osm(){ compose_run 'openstreetmap' npm start; }
-function import_polylines(){ compose_run 'polylines' npm start; }
-function import_transit(){ compose_run 'transit' npm start; }
+function import_wof(){ compose_run 'whosonfirst' './bin/start'; }
+function import_oa(){ compose_run 'openaddresses' './bin/start'; }
+function import_osm(){ compose_run 'openstreetmap' './bin/start'; }
+function import_polylines(){ compose_run 'polylines' './bin/start'; }
+function import_transit(){ compose_run 'transit' './bin/start'; }
 
 register 'import' 'wof' '(re)import whosonfirst data' import_wof
 register 'import' 'oa' '(re)import openaddresses data' import_oa


### PR DESCRIPTION
NPM can cause issues when running in docker containers, such as:
- requiring write access to the root filesystem and printing a large annoying warning if it doesn't have it
- not passing signals on to process it starts, making it take longer to gracefully kill containers

Now that all our Docker images have their own `start` and `download` scripts to serve as more reliable entry points, we can remove all calls to `npm` by the `pelias` script.

Connects https://github.com/pelias/pelias/issues/745