### PR TITLE
switch projects to use elasticsearch 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,9 @@ set -x
 # create directories
 mkdir /code /data
 
+# set proper permissions. make sure the user matches your `DOCKER_USER` setting in `.env`
+chown 1000:1000 /code /data
+
 # clone repo
 cd /code
 git clone https://github.com/pelias/docker.git

--- a/projects/australia/docker-compose.yml
+++ b/projects/australia/docker-compose.yml
@@ -93,7 +93,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch
+    image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
     restart: always
     ports: [ "9200:9200", "9300:9300" ]

--- a/projects/australia/pelias.json
+++ b/projects/australia/pelias.json
@@ -4,6 +4,7 @@
     "timestamp": false
   },
   "esclient": {
+    "apiVersion": "5.6",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/france/docker-compose.yml
+++ b/projects/france/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch
+    image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
     restart: always
     ports: [ "9200:9200", "9300:9300" ]

--- a/projects/france/pelias.json
+++ b/projects/france/pelias.json
@@ -4,6 +4,7 @@
     "timestamp": false
   },
   "esclient": {
+    "apiVersion": "5.6",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/los-angeles-metro/docker-compose.yml
+++ b/projects/los-angeles-metro/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch
+    image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
     restart: always
     ports: [ "9200:9200", "9300:9300" ]

--- a/projects/los-angeles-metro/pelias.json
+++ b/projects/los-angeles-metro/pelias.json
@@ -4,6 +4,7 @@
     "timestamp": false
   },
   "esclient": {
+    "apiVersion": "5.6",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch
+    image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
     restart: always
     ports: [ "9200:9200", "9300:9300" ]

--- a/projects/portland-metro/pelias.json
+++ b/projects/portland-metro/pelias.json
@@ -4,6 +4,7 @@
     "timestamp": false
   },
   "esclient": {
+    "apiVersion": "5.6",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/south-africa/docker-compose.yml
+++ b/projects/south-africa/docker-compose.yml
@@ -100,7 +100,7 @@ services:
     volumes:
       - "../../common/preview:/usr/share/nginx/html"
   elasticsearch:
-    image: pelias/elasticsearch
+    image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
     restart: always
     ports: [ "9200:9200", "9300:9300" ]

--- a/projects/south-africa/pelias.json
+++ b/projects/south-africa/pelias.json
@@ -4,6 +4,7 @@
     "timestamp": false
   },
   "esclient": {
+    "apiVersion": "5.6",
     "hosts": [
       { "host": "elasticsearch" }
     ]


### PR DESCRIPTION
Depends on https://github.com/pelias/schema/pull/323, please merge that first and wait for a new version of the `pelias/schema:latest` branch to be published to dockerhub.

Many projects are also based off the experimental `pelias/schema:portland-synonyms` image, so that image will need to pull in master after 323 is merged and then republished to dockerhub.

