### PR TITLE
set discovery.type in Dockefile

### DIFF
--- a/images/elasticsearch/5.6.12/Dockerfile
+++ b/images/elasticsearch/5.6.12/Dockerfile
@@ -9,6 +9,7 @@ ENV ES_JAVA_OPTS '-Xms512m -Xmx512m'
 ENV xpack.security.enabled 'false'
 ENV xpack.monitoring.enabled 'false'
 ENV cluster.name 'pelias-dev'
+ENV discovery.type 'single-node'
 ENV bootstrap.memory_lock 'true'
 RUN echo 'vm.max_map_count=262144' >> /etc/sysctl.conf
 


### PR DESCRIPTION
I missed this setting in https://github.com/pelias/docker/pull/24

Having this set in the image avoids having to remember to set it all the time during dev :)