### PR TITLE
Add example of using CSV importer

### DIFF
--- a/cmd/download.sh
+++ b/cmd/download.sh
@@ -8,12 +8,14 @@ function download_osm(){ compose_run 'openstreetmap' './bin/download'; }
 function download_geonames(){ compose_run 'geonames' './bin/download'; }
 function download_tiger(){ compose_run 'interpolation' './bin/download-tiger'; }
 function download_transit(){ compose_run 'transit' './bin/download'; }
+function download_csv(){ compose_run 'csv-importer' './bin/download'; }
 
 register 'download' 'wof' '(re)download whosonfirst data' download_wof
 register 'download' 'oa' '(re)download openaddresses data' download_oa
 register 'download' 'osm' '(re)download openstreetmap data' download_osm
 register 'download' 'tiger' '(re)download TIGER data' download_tiger
 register 'download' 'transit' '(re)download transit data' download_transit
+register 'download' 'csv' '(re)download csv data' download_csv
 
 # download all the data to be used by imports
 function download_all(){
@@ -27,6 +29,7 @@ function download_all(){
 
   download_tiger &
   download_transit &
+  download_csv &
   wait
 }
 

--- a/cmd/import.sh
+++ b/cmd/import.sh
@@ -8,6 +8,7 @@ function import_osm(){ compose_run 'openstreetmap' './bin/start'; }
 function import_polylines(){ compose_run 'polylines' './bin/start'; }
 function import_geonames(){ compose_run 'geonames' './bin/start'; }
 function import_transit(){ compose_run 'transit' './bin/start'; }
+function import_csv(){ compose_run 'csv-importer' './bin/start'; }
 
 register 'import' 'wof' '(re)import whosonfirst data' import_wof
 register 'import' 'oa' '(re)import openaddresses data' import_oa
@@ -15,6 +16,7 @@ register 'import' 'osm' '(re)import openstreetmap data' import_osm
 register 'import' 'polylines' '(re)import polylines data' import_polylines
 register 'import' 'geonames' '(re)import geonames data' import_geonames
 register 'import' 'transit' '(re)import transit data' import_transit
+register 'import' 'csv' '(re)import csv data' import_csv
 
 # import all the data to be used by imports
 # note: running importers in parallel can cause issues due to high CPU & RAM requirements.
@@ -29,6 +31,7 @@ function import_all(){
   fi
 
   import_transit
+  import_csv
 }
 
 register 'import' 'all' '(re)import all data' import_all

--- a/projects/australia/docker-compose.yml
+++ b/projects/australia/docker-compose.yml
@@ -66,6 +66,14 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
+  csv-importer:
+    image: pelias/csv-importer:master
+    container_name: pelias_csv_importer
+    user: "${DOCKER_USER}"
+    volumes:
+      - "./pelias.json:/code/pelias.json"
+      - "${DATA_DIR}:/data"
+      - "./blacklist/:/data/blacklist"
   polylines:
     image: pelias/polylines:master
     container_name: pelias_polylines

--- a/projects/france/docker-compose.yml
+++ b/projects/france/docker-compose.yml
@@ -56,6 +56,14 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
+  csv-importer:
+    image: pelias/csv-importer:master
+    container_name: pelias_csv_importer
+    user: "${DOCKER_USER}"
+    volumes:
+      - "./pelias.json:/code/pelias.json"
+      - "${DATA_DIR}:/data"
+      - "./blacklist/:/data/blacklist"
   polylines:
     image: pelias/polylines:master
     container_name: pelias_polylines

--- a/projects/los-angeles-metro/docker-compose.yml
+++ b/projects/los-angeles-metro/docker-compose.yml
@@ -58,6 +58,14 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
+  csv-importer:
+    image: pelias/csv-importer:master
+    container_name: pelias_csv_importer
+    user: "${DOCKER_USER}"
+    volumes:
+      - "./pelias.json:/code/pelias.json"
+      - "${DATA_DIR}:/data"
+      - "./blacklist/:/data/blacklist"
   transit:
     image: pelias/transit:master
     container_name: pelias_transit

--- a/projects/north-america/docker-compose.yml
+++ b/projects/north-america/docker-compose.yml
@@ -49,6 +49,14 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
+  csv-importer:
+    image: pelias/csv-importer:master
+    container_name: pelias_csv_importer
+    user: "${DOCKER_USER}"
+    volumes:
+      - "./pelias.json:/code/pelias.json"
+      - "${DATA_DIR}:/data"
+      - "./blacklist/:/data/blacklist"
   transit:
     image: pelias/transit:master
     container_name: pelias_transit

--- a/projects/planet/docker-compose.yml
+++ b/projects/planet/docker-compose.yml
@@ -67,6 +67,14 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
       - "./blacklist/:/data/blacklist"
+  csv-importer:
+    image: pelias/csv-importer:master
+    container_name: pelias_csv_importer
+    user: "${DOCKER_USER}"
+    volumes:
+      - "./pelias.json:/code/pelias.json"
+      - "${DATA_DIR}:/data"
+      - "./blacklist/:/data/blacklist"
   transit:
     image: pelias/transit:master
     container_name: pelias_transit

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -66,6 +66,14 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
+  csv-importer:
+    image: pelias/csv-importer:master
+    container_name: pelias_csv_importer
+    user: "${DOCKER_USER}"
+    volumes:
+      - "./pelias.json:/code/pelias.json"
+      - "${DATA_DIR}:/data"
+      - "./blacklist/:/data/blacklist"
   polylines:
     image: pelias/polylines:master
     container_name: pelias_polylines

--- a/projects/portland-metro/pelias.json
+++ b/projects/portland-metro/pelias.json
@@ -45,6 +45,13 @@
         "/data/blacklist/osm.txt"
       ]
     },
+    "csv": {
+      "datapath": "/data/csv",
+      "files": [],
+      "download": [
+        "https://raw.githubusercontent.com/pelias/csv-importer/master/data/example.csv"
+      ]
+    },
     "geonames": {
       "datapath": "/data/geonames",
       "countryCode": "ALL"

--- a/projects/san-jose-metro/docker-compose.yml
+++ b/projects/san-jose-metro/docker-compose.yml
@@ -58,6 +58,14 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
+  csv-importer:
+    image: pelias/csv-importer:master
+    container_name: pelias_csv_importer
+    user: "${DOCKER_USER}"
+    volumes:
+      - "./pelias.json:/code/pelias.json"
+      - "${DATA_DIR}:/data"
+      - "./blacklist/:/data/blacklist"
   transit:
     image: pelias/transit:master
     container_name: pelias_transit

--- a/projects/south-africa/docker-compose.yml
+++ b/projects/south-africa/docker-compose.yml
@@ -59,6 +59,14 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
+  csv-importer:
+    image: pelias/csv-importer:master
+    container_name: pelias_csv_importer
+    user: "${DOCKER_USER}"
+    volumes:
+      - "./pelias.json:/code/pelias.json"
+      - "${DATA_DIR}:/data"
+      - "./blacklist/:/data/blacklist"
   transit:
     image: pelias/transit:master
     container_name: pelias_transit


### PR DESCRIPTION
The new [csv-importer](https://github.com/pelias/csv-importer) is built to import arbitrary custom data into Pelias from CSV files.

This PR includes it in the Pelias CLI and all project `docker-compose.yml` files.

The importer is designed to do nothing if there's no configuration block in `pelias.json`, and such a configuration is only added for the Pelias metro project, with a small example CSV used in that case.