### PR TITLE
Update valhalla image to use Ubuntu 16.04, and add pelias cli for valhalla.

### DIFF
--- a/cmd/prepare.sh
+++ b/cmd/prepare.sh
@@ -3,6 +3,8 @@ set -e;
 
 # per-source prepares
 function prepare_polylines(){ compose_run 'polylines' bash ./docker_extract.sh; }
+# alternative creation method for polyline data using valhalla
+function prepare_valhalla(){ compose_run 'valhalla' bash ./docker_build.sh; }
 function prepare_interpolation(){ compose_run 'interpolation' bash ./docker_build.sh; }
 function prepare_placeholder(){
   compose_run 'placeholder' ./cmd/extract.sh;
@@ -10,6 +12,7 @@ function prepare_placeholder(){
 }
 
 register 'prepare' 'polylines' 'export road network from openstreetmap into polylines format' prepare_polylines
+register 'prepare' 'valhalla' 'export road network from openstreetmap into polylines format using valhalla' prepare_valhalla
 register 'prepare' 'interpolation' 'build interpolation sqlite databases' prepare_interpolation
 register 'prepare' 'placeholder' 'build placeholder sqlite databases' prepare_placeholder
 
@@ -21,4 +24,12 @@ function prepare_all(){
   prepare_interpolation
 }
 
+function prepare_all_valhalla(){
+  prepare_valhalla &
+  prepare_placeholder &
+  wait
+  prepare_interpolation
+}
+
 register 'prepare' 'all' 'build all services which have a prepare step' prepare_all
+register 'prepare' 'all_valhalla' 'build all services which have a prepare step using valhalla for polylines' prepare_all_valhalla

--- a/images/valhalla/Dockerfile
+++ b/images/valhalla/Dockerfile
@@ -1,25 +1,35 @@
 # base image
-FROM pelias/baseimage
+FROM ubuntu:16.04
 
-# grab all of the valhalla software from ppa
-RUN apt-get update && \
-    apt-get install -y software-properties-common python-software-properties && \
-    add-apt-repository -y ppa:kevinkreiser/prime-server && \
-    add-apt-repository -y ppa:valhalla-routing/valhalla && \
-    apt-get update && \
-    apt-get install -y valhalla-bin && \
-    rm -rf /var/lib/apt/lists/*;
+# configure env
+ENV DEBIAN_FRONTEND 'noninteractive'
 
-# change working dir
-RUN mkdir -p /code/valhalla
-WORKDIR /code/valhalla
+RUN apt-get update && apt-get install -y locales apt-utils iputils-ping curl wget git-core autoconf automake libtool pkg-config python
 
-# generate config
+RUN apt-get install -y software-properties-common && \
+    apt-get update
+
+RUN add-apt-repository -y ppa:valhalla-core/valhalla && \
+    apt-get update
+
+RUN apt-get install -y valhalla-bin
+
+# configure volumes
+VOLUME "/data"
+
+
+# generate valhalla config
 RUN valhalla_build_config \
-  --mjolnir-tile-dir '/data/valhalla' \
-  --mjolnir-tile-extract '/data/valhalla.tar' \
-  --mjolnir-timezone '/data/valhalla/timezones.sqlite' \
-  --mjolnir-admin '/data/valhalla/admins.sqlite' > valhalla.json
+  --mjolnir-tile-dir '/data/valhalla/valhalla_tiles' \
+  --mjolnir-tile-extract '/data/valhalla/valhalla_tiles.tar' \
+  --mjolnir-timezone '/data/valhalla/valhalla_tiles/timezones.sqlite' \
+  --mjolnir-admin '/data/valhalla/valhalla_tiles/admins.sqlite' > valhalla.json
 
-# build script
-RUN echo 'valhalla_build_tiles -c valhalla.json /data/openstreetmap/*.osm.pbf; valhalla_export_edges --config valhalla.json > /data/polylines/pbf_extract.polyline;' > ./docker_build.sh
+# build script to build tiles and export polyline data.
+RUN echo 'mkdir -p /data/valhalla/valhalla_tiles\n' \
+         'touch /data/valhalla/valhalla_tiles/timezones.sqlite\n' \
+         'touch /data/valhalla/valhalla_tiles/admins.sqlite\n' \
+         'mkdir -p /data/polylines\n' \
+         'valhalla_build_tiles -c valhalla.json /data/openstreetmap/*.osm.pbf;\n' \
+         'find /data/valhalla/valhalla_tiles | sort -n | tar cf /data/valhalla/valhalla_tiles.tar --no-recursion -T - \n' \
+         'valhalla_export_edges --config valhalla.json >> /data/polylines/extract.0sv;' > ./docker_build.sh

--- a/projects/france/docker-compose.yml
+++ b/projects/france/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     restart: always
     ports: [ "4400:4400" ]
   schema:
-    image: pelias/schema:portland-synonyms
+    image: pelias/schema:support_both_es2_and_es5_plus_portland_synonyms
     container_name: pelias_schema
     user: "${DOCKER_USER}"
     volumes:
@@ -100,3 +100,10 @@ services:
     cap_add: [ "IPC_LOCK" ]
     security_opt:
       - seccomp=unconfined
+  valhalla:
+    container_name: pelias_valhalla
+    build: ../../images/valhalla
+    restart: "no"
+    volumes:
+      - "./pelias.json:/code/pelias.json"
+      - "${DATA_DIR}:/data"

--- a/projects/france/docker-compose.yml
+++ b/projects/france/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch
+    image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
     restart: always
     ports: [ "9200:9200", "9300:9300" ]

--- a/projects/france/pelias.json
+++ b/projects/france/pelias.json
@@ -4,6 +4,7 @@
     "timestamp": false
   },
   "esclient": {
+    "apiVersion": "5.6",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/los-angeles-metro/docker-compose.yml
+++ b/projects/los-angeles-metro/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     restart: always
     ports: [ "4400:4400" ]
   schema:
-    image: pelias/schema:portland-synonyms
+    image: pelias/schema:support_both_es2_and_es5_plus_portland_synonyms
     container_name: pelias_schema
     user: "${DOCKER_USER}"
     volumes:
@@ -115,3 +115,10 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "./test_cases:/code/pelias/fuzzy-tester/test_cases"
+  valhalla:
+    container_name: pelias_valhalla
+    build: ../../images/valhalla
+    restart: "no"
+    volumes:
+      - "./pelias.json:/code/pelias.json"
+      - "${DATA_DIR}:/data"

--- a/projects/los-angeles-metro/docker-compose.yml
+++ b/projects/los-angeles-metro/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch
+    image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
     restart: always
     ports: [ "9200:9200", "9300:9300" ]

--- a/projects/los-angeles-metro/pelias.json
+++ b/projects/los-angeles-metro/pelias.json
@@ -4,6 +4,7 @@
     "timestamp": false
   },
   "esclient": {
+    "apiVersion": "5.6",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     restart: always
     ports: [ "4400:4400" ]
   schema:
-    image: pelias/schema:portland-synonyms
+    image: pelias/schema:support_both_es2_and_es5_plus_portland_synonyms
     container_name: pelias_schema
     user: "${DOCKER_USER}"
     volumes:
@@ -118,3 +118,10 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "./test_cases:/code/pelias/fuzzy-tester/test_cases"
+  valhalla:
+    container_name: pelias_valhalla
+    build: ../../images/valhalla
+    restart: "no"
+    volumes:
+      - "./pelias.json:/code/pelias.json"
+      - "${DATA_DIR}:/data"

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch
+    image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
     restart: always
     ports: [ "9200:9200", "9300:9300" ]

--- a/projects/portland-metro/pelias.json
+++ b/projects/portland-metro/pelias.json
@@ -4,6 +4,7 @@
     "timestamp": false
   },
   "esclient": {
+    "apiVersion": "5.6",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/south-africa/docker-compose.yml
+++ b/projects/south-africa/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     restart: always
     ports: [ "4400:4400" ]
   schema:
-    image: pelias/schema:master
+    image: pelias/schema:support_both_es2_and_es5
     container_name: pelias_schema
     user: "${DOCKER_USER}"
     volumes:
@@ -123,3 +123,10 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "./test_cases:/code/pelias/fuzzy-tester/test_cases"
+  valhalla:
+    container_name: pelias_valhalla
+    build: ../../images/valhalla
+    restart: "no"
+    volumes:
+      - "./pelias.json:/code/pelias.json"
+      - "${DATA_DIR}:/data"

--- a/projects/south-africa/docker-compose.yml
+++ b/projects/south-africa/docker-compose.yml
@@ -100,7 +100,7 @@ services:
     volumes:
       - "../../common/preview:/usr/share/nginx/html"
   elasticsearch:
-    image: pelias/elasticsearch
+    image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
     restart: always
     ports: [ "9200:9200", "9300:9300" ]

--- a/projects/south-africa/pelias.json
+++ b/projects/south-africa/pelias.json
@@ -4,6 +4,7 @@
     "timestamp": false
   },
   "esclient": {
+    "apiVersion": "5.6",
     "hosts": [
       { "host": "elasticsearch" }
     ]


### PR DESCRIPTION
This updates the valhalla image used in the docker setup, and creates a command to use it as an alternative to the normal polyline creation metod.

Some notes on this update as it was incredibly frustrating to get working:
Moved away from `pelias/baseimage` as the base docker image for valhalla. There are a couple reasons for this. The install instructions originally used in the image that relied on the PPA recipe don't work for Ubuntu latest (18.04). After finding this out, I attempted to build the project from source using the `pelias/baseimage` and was able to get it successfully building + linking, but found that there was one, and only one, specific test in valhalla failing afterwards. This test failure coupled with a consistently stalled import of polyline data when running through the portland test case had me guessing this test failure was causing an issue. I tried to track down this error for quite a while thinking it was related to how libraries were being linked/loaded before ultimately coming across this closed issue in the valhalla repo actually referencing it. 
https://github.com/valhalla/valhalla/issues/1437
Unfortunately, this closed issue didn't actually fix the underlying problem but it did identify it. ( I wish this was documented anywhere else in the readme or documentation for the actual repo. One would think if there is a known test issue with a latest distribution of ubuntu it would be documented somewhere in the readme, so some developer like myself who sees a passing latest linux build with no open issues surrounding the test in question doesn't spend hours thinking some library is configured incorrectly.)
So after falling back to using the last known working ubuntu release, the recipe works again for the install, so I dropped building from source all together. I also created some commands to use valhalla as an alternative means to generating the polyline data. 
I ran through the portland test using valhalla successfully with 98% of the tests passing, but haven't run through the other projects yet. If others could test out the different projects and verify they are able to run through the projects successfully this change should be ready to pull in. It might be worthwhile to update the larger country/continent projects readme to use the valhalla method of polyline generation since it's intended for larger pbf files, but I figured we can add that to the PR quickly if that makes the most sense.  

