### PR TITLE
Acceptance-tests docker-compose service

### DIFF
--- a/cmd/test.sh
+++ b/cmd/test.sh
@@ -3,5 +3,7 @@ set -e;
 
 # run acceptance tests
 function test_fuzzy(){ compose_run 'fuzzy-tester' -e 'docker' $@; }
+function test_acceptance() { compose_run 'acceptance-tests' npm test -- -e 'docker' $@; }
 
 register 'test' 'run' 'run fuzzy-tester test cases' test_fuzzy
+register 'test' 'acceptance-tests' 'run acceptance-tests test cases' test_acceptance

--- a/images/acceptance-tests/Dockerfile
+++ b/images/acceptance-tests/Dockerfile
@@ -1,0 +1,17 @@
+# base image
+FROM pelias/baseimage
+
+# clone repo
+RUN git clone https://github.com/pelias/acceptance-tests.git /code/pelias/acceptance-tests
+
+# change working dir
+WORKDIR /code/pelias/acceptance-tests
+
+# consume the build variables
+ARG REVISION=master
+
+# switch to desired revision
+RUN git checkout $REVISION
+
+# install npm dependencies
+RUN npm install

--- a/projects/france/docker-compose.yml
+++ b/projects/france/docker-compose.yml
@@ -100,3 +100,10 @@ services:
     cap_add: [ "IPC_LOCK" ]
     security_opt:
       - seccomp=unconfined
+  acceptance-tests:
+    container_name: pelias_acceptance_tests
+    build: ../../images/acceptance-tests
+    user: "${DOCKER_USER}"
+    restart: "no"
+    volumes:
+      - "./pelias.json:/code/pelias.json"

--- a/projects/france/docker-compose.yml
+++ b/projects/france/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch
+    image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
     restart: always
     ports: [ "9200:9200", "9300:9300" ]

--- a/projects/france/pelias.json
+++ b/projects/france/pelias.json
@@ -4,6 +4,7 @@
     "timestamp": false
   },
   "esclient": {
+    "apiVersion": "5.6",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/france/pelias.json
+++ b/projects/france/pelias.json
@@ -18,6 +18,11 @@
       }
     }
   },
+  "acceptance-tests": {
+    "endpoints": {
+      "docker": "http://api:4000/v1/"
+    }
+  },
   "api": {
     "textAnalyzer": "libpostal",
     "services": {

--- a/projects/los-angeles-metro/docker-compose.yml
+++ b/projects/los-angeles-metro/docker-compose.yml
@@ -115,3 +115,10 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "./test_cases:/code/pelias/fuzzy-tester/test_cases"
+  acceptance-tests:
+    container_name: pelias_acceptance_tests
+    build: ../../images/acceptance-tests
+    user: "${DOCKER_USER}"
+    restart: "no"
+    volumes:
+      - "./pelias.json:/code/pelias.json"

--- a/projects/los-angeles-metro/docker-compose.yml
+++ b/projects/los-angeles-metro/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch
+    image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
     restart: always
     ports: [ "9200:9200", "9300:9300" ]

--- a/projects/los-angeles-metro/pelias.json
+++ b/projects/los-angeles-metro/pelias.json
@@ -4,6 +4,7 @@
     "timestamp": false
   },
   "esclient": {
+    "apiVersion": "5.6",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -118,3 +118,10 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "./test_cases:/code/pelias/fuzzy-tester/test_cases"
+  acceptance-tests:
+    container_name: pelias_acceptance_tests
+    build: ../../images/acceptance-tests
+    user: "${DOCKER_USER}"
+    restart: "no"
+    volumes:
+      - "./pelias.json:/code/pelias.json"

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch
+    image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
     restart: always
     ports: [ "9200:9200", "9300:9300" ]

--- a/projects/portland-metro/pelias.json
+++ b/projects/portland-metro/pelias.json
@@ -4,6 +4,7 @@
     "timestamp": false
   },
   "esclient": {
+    "apiVersion": "5.6",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/portland-metro/pelias.json
+++ b/projects/portland-metro/pelias.json
@@ -121,14 +121,6 @@
         },
         {
           "layerId": "stops",
-          "url": "http://cherriots.org/developer/gtfs.zip",
-          "filename": "CHERRIOTS-stops.txt",
-          "agencyId": "CHERRIOTS",
-          "agencyName": "Cherriots",
-          "layerName": "Stop"
-        },
-        {
-          "layerId": "stops",
           "url": "http://oregon-gtfs.com/gtfs_data/sandy-or-us/sandy-or-us.zip",
           "filename": "SAM-stops.txt",
           "agencyId": "SAM",

--- a/projects/south-africa/docker-compose.yml
+++ b/projects/south-africa/docker-compose.yml
@@ -123,3 +123,10 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "./test_cases:/code/pelias/fuzzy-tester/test_cases"
+  acceptance-tests:
+    container_name: pelias_acceptance_tests
+    build: ../../images/acceptance-tests
+    user: "${DOCKER_USER}"
+    restart: "no"
+    volumes:
+      - "./pelias.json:/code/pelias.json"

--- a/projects/south-africa/docker-compose.yml
+++ b/projects/south-africa/docker-compose.yml
@@ -100,7 +100,7 @@ services:
     volumes:
       - "../../common/preview:/usr/share/nginx/html"
   elasticsearch:
-    image: pelias/elasticsearch
+    image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
     restart: always
     ports: [ "9200:9200", "9300:9300" ]

--- a/projects/south-africa/pelias.json
+++ b/projects/south-africa/pelias.json
@@ -4,6 +4,7 @@
     "timestamp": false
   },
   "esclient": {
+    "apiVersion": "5.6",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/south-africa/test_cases/search_address.json
+++ b/projects/south-africa/test_cases/search_address.json
@@ -1,6 +1,6 @@
 {
   "name": "/v1/search address",
-  "description": "addresses in Portland, OR",
+  "description": "addresses in South Africa",
   "priorityThresh": 1,
   "normalizers": {
     "name": [


### PR DESCRIPTION
Created a docker-compose service to quickly setup and run the acceptance-test repo as an alternative test set to run against each project. Also removed an invalid url for data download in the portland test case.