### PR TITLE
fix(docs): Add line setting proper permissions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,9 @@ set -x
 # create directories
 mkdir /code /data
 
+# set proper permissions. make sure the user matches your `DOCKER_USER` setting in `.env`
+chown 1000:1000 /code /data
+
 # clone repo
 cd /code
 git clone https://github.com/pelias/docker.git


### PR DESCRIPTION
As part of our switch to running Pelias containers as non-root users (https://github.com/pelias/pelias/issues/745), it's now important that the directory used for Pelias data has proper permissions.

It's very easy for the data directory to end up being writable either only by the `root` user or a user different than the one running in the Pelias containers, in which case nothing will work .

This line in the example script should make things right.