### PR TITLE
Fix es5 startup

### DIFF
--- a/cmd/elastic.sh
+++ b/cmd/elastic.sh
@@ -21,11 +21,22 @@ register 'elastic' 'status' 'HTTP status code of the elasticsearch service' elas
 
 function elastic_wait(){
   echo 'waiting for elasticsearch service to come up';
-  until test $(elastic_status) -eq 200; do
-    printf '.'
+  retry_count=30
+
+  i=1
+  while [[ "$i" -le "$retry_count" ]]; do
+    if [[ $(elastic_status) -eq 200 ]]; then
+      echo
+      exit 0
+    fi
     sleep 2
+    printf "."
+    i=$(($i + 1))
   done
+
   echo
+  echo "Elasticsearch did not come up, check configuration"
+  exit 1
 }
 
 register 'elastic' 'wait' 'wait for elasticsearch to start up' elastic_wait

--- a/cmd/elastic.sh
+++ b/cmd/elastic.sh
@@ -3,7 +3,7 @@ set -e;
 
 function elastic_schema_drop(){ compose_run 'schema' node scripts/drop_index "$@" || true; }
 function elastic_schema_create(){ compose_run 'schema' node scripts/create_index; }
-function elastic_start(){ compose_exec up -d elasticsearch; }
+function elastic_start(){ mkdir -p $DATA_DIR/elasticsearch; compose_exec up -d elasticsearch; }
 function elastic_stop(){ compose_exec kill elasticsearch; }
 
 register 'elastic' 'drop' 'delete elasticsearch index & all data' elastic_schema_drop

--- a/projects/australia/pelias.json
+++ b/projects/australia/pelias.json
@@ -68,11 +68,6 @@
         "85632793"
       ]
     },
-    "transit": {
-      "datapath": "/data/transit",
-      "feeds": [
-      ]
-    },
     "interpolation": {
       "download": {
         "tiger": {


### PR DESCRIPTION
This puts in a very basic fix for ES5 related startup issues as described in #33.

Additionally, it fixes #34 by limiting how long `pelias elastic wait` will wait for Elasticsearch to start. The limit is 60 seconds.