### PR TITLE
feat(es5-image): Add `repository-s3` plugin

### DIFF
--- a/images/elasticsearch/5.6.12/Dockerfile
+++ b/images/elasticsearch/5.6.12/Dockerfile
@@ -15,6 +15,7 @@ RUN echo 'vm.max_map_count=262144' >> /etc/sysctl.conf
 
 # configure plugins
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu
+RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install repository-s3
 
 # elasticsearch config
 ADD elasticsearch.yml /usr/share/elasticsearch/config/


### PR DESCRIPTION
In order to upload snapshots to s3, the `repository-s3` plugin is required.

A new image with this change has been pushed to `pelias/elasticsearch:5.6.12` on hub.docker.com