### PR TITLE
feat(docker): Enable TTY when running docker containers

### DIFF
--- a/cmd/docker.sh
+++ b/cmd/docker.sh
@@ -16,7 +16,7 @@ register 'compose' 'top' 'display the running processes of a container' compose_
 function compose_exec(){ docker-compose $@; }
 register 'compose' 'exec' 'execute an arbitrary docker-compose command' compose_exec
 
-function compose_run(){ docker-compose run -T --rm $@; }
+function compose_run(){ docker-compose run --rm $@; }
 register 'compose' 'run' 'execute a docker-compose run command' compose_run
 
 function compose_up(){ docker-compose up -d $@; }


### PR DESCRIPTION
This is required in order to see color output from the acceptance tests.

@missinglink, do you recall why we originally disabled TTYs?