### PR TITLE
feat(pelias-cmd): Support OpenAddresses paralell imports

### DIFF
--- a/cmd/import.sh
+++ b/cmd/import.sh
@@ -3,7 +3,7 @@ set -e;
 
 # per-source imports
 function import_wof(){ compose_run 'whosonfirst' './bin/start'; }
-function import_oa(){ compose_run 'openaddresses' './bin/start'; }
+function import_oa(){ compose_run 'openaddresses' "./bin/parallel ${OPENADDRESSES_PARALLELISM:-1}"; }
 function import_osm(){ compose_run 'openstreetmap' './bin/start'; }
 function import_polylines(){ compose_run 'polylines' './bin/start'; }
 function import_transit(){ compose_run 'transit' './bin/start'; }


### PR DESCRIPTION
Use the parallel build script from OpenAddresses to allow for multiple parallel builds.

This feature is experimental for now, and will not yet be documented.