### PR TITLE
docker: run chown on Elasticsearch directory

### DIFF
--- a/cmd/elastic.sh
+++ b/cmd/elastic.sh
@@ -3,7 +3,12 @@ set -e;
 
 function elastic_schema_drop(){ compose_run 'schema' node scripts/drop_index "$@" || true; }
 function elastic_schema_create(){ compose_run 'schema' node scripts/create_index; }
-function elastic_start(){ mkdir -p $DATA_DIR/elasticsearch; compose_exec up -d elasticsearch; }
+function elastic_start(){
+  mkdir -p $DATA_DIR/elasticsearch
+  chown $DOCKER_USER $DATA_DIR/elasticsearch
+  compose_exec up -d elasticsearch
+}
+
 function elastic_stop(){ compose_exec kill elasticsearch; }
 
 register 'elastic' 'drop' 'delete elasticsearch index & all data' elastic_schema_drop


### PR DESCRIPTION
With Elasticsearch 5, proper permissions (by default for user 1000) must
be set on the data directory on the host system.

Users have consistently run the `pelias` helper script as users with a
different UID than 1000, or the one configured in `.env` (usually root),
so this change uses `chown` to set ownership of the Elasticsearch data
directory.

Connects https://github.com/pelias/docker/issues/33
Connects https://github.com/pelias/docker/issues/53