### PR TITLE
Updated Metro Extract Area and Addresses

### DIFF
--- a/projects/san-jose-metro/pelias.json
+++ b/projects/san-jose-metro/pelias.json
@@ -59,7 +59,7 @@
       "files": [
         "us/ca/city_of_san_jose.csv",
 		"us/ca/city_of_san_jose2.csv",
-		"us/ca/city_of_santa_clara.csv"
+		"us/ca/city_of_santa_clara.csv",
 		"us/ca/city_of_cupertino.csv",
 		"us/ca/city_of_mountain_view.csv",
 		"us/ca/city_of_palo_alto.csv",


### PR DESCRIPTION
Updated the project code for San José Metro to increase the Metro Extract to include all of Santa Clara County.  Plus adding in additional address data. 