### PR TITLE
fix(ES image): Allow running Elasticsearch 5 container as any user

### DIFF
--- a/images/elasticsearch/5.6.12/Dockerfile
+++ b/images/elasticsearch/5.6.12/Dockerfile
@@ -21,5 +21,20 @@ RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install repository-s3
 ADD elasticsearch.yml /usr/share/elasticsearch/config/
 RUN chown elasticsearch:elasticsearch config/elasticsearch.yml
 
+## set permissions so any user can run elasticsearch
+# add read permissions to all files in dir
+RUN chmod go+r /usr/share/elasticsearch -R
+# add write permissions to config dir
+RUN chmod go+w /usr/share/elasticsearch \
+    /usr/share/elasticsearch/config
+# add list permissions to directorys
+RUN chmod go+x /usr/share/elasticsearch \
+    /usr/share/elasticsearch/config \
+	/usr/share/elasticsearch/config/ingest-geoip \
+	/usr/share/elasticsearch/config/x-pack \
+	/usr/share/elasticsearch/config/repository-s3
+# add execute permissions to bins
+RUN chmod go+x /usr/share/elasticsearch/bin/*
+
 # run as elasticsearch user
 USER elasticsearch

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -95,6 +95,7 @@ services:
   elasticsearch:
     image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
+    user: "${DOCKER_USER}"
     restart: always
     ports: [ "9200:9200", "9300:9300" ]
     volumes:


### PR DESCRIPTION
This sets some more permissive permissions on various directories,
files, and executables used in the Elasticsearch 5 docker image.

It allows the user the container processes run under to be changed from
the default of 1000, which helps keep things consistent with the rest of
the Pelias containers.

Fixes https://github.com/pelias/docker/issues/46