### PR TITLE
fix(cli): Handle chown failures when running as non-root

### DIFF
--- a/cmd/elastic.sh
+++ b/cmd/elastic.sh
@@ -5,7 +5,8 @@ function elastic_schema_drop(){ compose_run 'schema' node scripts/drop_index "$@
 function elastic_schema_create(){ compose_run 'schema' node scripts/create_index; }
 function elastic_start(){
   mkdir -p $DATA_DIR/elasticsearch
-  chown $DOCKER_USER $DATA_DIR/elasticsearch
+  # attemp to set proper permissions if running as root
+  chown $DOCKER_USER $DATA_DIR/elasticsearch 2>/dev/null || true
   compose_exec up -d elasticsearch
 }
 


### PR DESCRIPTION
In https://github.com/pelias/docker/pull/55 we added a `chown` line that attempts to set proper permissions on the Elasticsearch data directory.

`chown` can generally only be run as root, so this PR adds handling for the common case where `chown` fails.

In general, either the pelias CLI is run as root, and the `chown` will succeed, or the CLI is run as the same user the Docker container processes will run as. In this case the `mkdir` on the preceding line will set up the directory with proper ownership.

We can't really do anything in an automated way to handle people running the Pelias CLI as a different, non-root, user than the one they want the containers to run with, so I think this is the best we can do.

This will be even more useful once https://github.com/pelias/docker/pull/62 is merged.