### PR TITLE
fix(net): Safely initialize Docker network

### DIFF
--- a/cmd/docker.sh
+++ b/cmd/docker.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e;
 
+function net_init(){
+  docker network create ${COMPOSE_PROJECT_NAME}_default >/dev/null || true
+}
+
 function compose_pull(){ compose_exec pull; }
 register 'compose' 'pull' 'update all docker images' compose_pull
 
@@ -16,7 +20,7 @@ register 'compose' 'top' 'display the running processes of a container' compose_
 function compose_exec(){ docker-compose $@; }
 register 'compose' 'exec' 'execute an arbitrary docker-compose command' compose_exec
 
-function compose_run(){ docker-compose run --rm $@; }
+function compose_run(){ net_init; docker-compose run --rm $@; }
 register 'compose' 'run' 'execute a docker-compose run command' compose_run
 
 function compose_up(){ docker-compose up -d $@; }


### PR DESCRIPTION
The Pelias CLI was relying on the fact that a command such as `pelias
elastic start`, which only starts one container, was run before commands such as `pelias import all`, which can start many containers very quickly.


This PR adds a call to `docker network create ...` before starting any containers, which removes the possibility of multiple duplicate networks being created.

This prevents issues with errors such as:
```
ERROR: 5 matches found based on name: network pelias_default is
ambiguous
```

when running commands on the Pelias CLI.

Connects https://github.com/pelias/docker/issues/51