### PR TITLE
fix(schema): Use entrypoint script to create ES index

### DIFF
--- a/cmd/elastic.sh
+++ b/cmd/elastic.sh
@@ -2,7 +2,7 @@
 set -e;
 
 function elastic_schema_drop(){ compose_run 'schema' node scripts/drop_index "$@" || true; }
-function elastic_schema_create(){ compose_run 'schema' node scripts/create_index; }
+function elastic_schema_create(){ compose_run 'schema' ./bin/create_index; }
 function elastic_start(){
   mkdir -p $DATA_DIR/elasticsearch
   # attemp to set proper permissions if running as root


### PR DESCRIPTION
As of https://github.com/pelias/schema/pull/340, it's required to use the `./bin/create_index` entrypoint script to use pelias/schema to create an Elasticsearch index.

This entrypoint script sets proper command line flags, and generally fits the pattern of our own custom scripts to set reasonable defaults where required.