### PR TITLE
Use schema master branch everywhere

### DIFF
--- a/projects/france/docker-compose.yml
+++ b/projects/france/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     restart: always
     ports: [ "4400:4400" ]
   schema:
-    image: pelias/schema:portland-synonyms
+    image: pelias/schema:master
     container_name: pelias_schema
     user: "${DOCKER_USER}"
     volumes:

--- a/projects/los-angeles-metro/docker-compose.yml
+++ b/projects/los-angeles-metro/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     restart: always
     ports: [ "4400:4400" ]
   schema:
-    image: pelias/schema:portland-synonyms
+    image: pelias/schema:master
     container_name: pelias_schema
     user: "${DOCKER_USER}"
     volumes:

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     restart: always
     ports: [ "4400:4400" ]
   schema:
-    image: pelias/schema:portland-synonyms
+    image: pelias/schema:master
     container_name: pelias_schema
     user: "${DOCKER_USER}"
     volumes:


### PR DESCRIPTION
Now that https://github.com/pelias/schema/pull/310 has been merged, using the `portland-synonyms` branch is no longer required.

Fixes #67 