### PR TITLE
feat(ES5): Increase bulk import queue_size to 1000

### DIFF
--- a/images/elasticsearch/5.6.12/elasticsearch.yml
+++ b/images/elasticsearch/5.6.12/elasticsearch.yml
@@ -4,3 +4,6 @@ network.host: 0.0.0.0
 http.port: 9200
 node.master: true
 node.data: true
+thread_pool:
+  bulk:
+    queue_size: 1000


### PR DESCRIPTION
The default was increased from 50 to 200 for ES5, but that's not enough
to allow all importers to run simultaneously on a planet sized import.

1000 is the same value we've used with ES2 and should continue to work
well. We haven't experienced any negative side effects to having this
set very high for smaller imports.

In theory, running an import on a very CPU constrained server would use
more memory storing things in the queue, but that hasn't been observed
to be a problem yet.

Connects https://github.com/pelias/pelias/issues/461