### PR TITLE
added scripts for a full setup on a single machine

### DIFF
--- a/tools/full_machine_setup_script/README.md
+++ b/tools/full_machine_setup_script/README.md
@@ -1,0 +1,78 @@
+
+# Full Pelias machine setup script with pelias/docker
+
+This script is aimed at performing a full install of a Pelias server instance from A to Z, with a single script launch.
+
+What this script does chronologically:
+* Installs base dependencies
+* Configures nginx to forward incoming 443 (https) requests to port localhost:4000
+* Creates a dedicated pelias user on the machine, configured to be usable with docker
+* Then run the following actions from the pelias user:
+  * Download the docker repo for pelias
+  * Configure the "planet" project to have all ports only accessible from localhost (4000, 4100, 4200, 4300, 4400, 9200, 9300)
+  * Run the pelias commands one by one to get the service fully operational with the planet project
+
+## How to use this script
+
+* Modify the following line in `pelias_setup_main_as_root.sh`:
+    ```
+    export SERVER_DOMAIN_NAME="write.your.domain.here"
+    ```
+* Copy the following files to your server:
+  * `pelias_setup_main_as_root.sh`
+  * `pelias_setup_user_level_part.sh`
+* Login to your server as root, and cd to the directory where those files have been copied
+* Open a screen with the `screen` command
+* Run the main script:
+    ```
+    sh pelias_setup_main_as_root.sh
+    ```
+* Wait a few days for the script to complete: depending on your machine, it could be 2 days, 14 days or more...
+* Make an example query (replacing "your.server.ip"): `https://your.server.ip/v1/search?text=portland` (modified example from [here](https://github.com/pelias/docker#make-an-example-query))
+
+## How to follow the progress of the script
+
+Running the script will generate the following logs file (you can create separate screens to follow the progress):
+* `./logs_pelias_setup.txt` (root user level logs)
+* `/home/pelias/logs_pelias_setup.txt` (pelias user level logs)
+* `/home/pelias/logs_pelias_setup_setup_details_for_pull.txt` (pelias user level logs for pull)
+* `/home/pelias/logs_pelias_setup_setup_details_for_es_start.txt` (pelias user level logs for es start)
+* `/home/pelias/logs_pelias_setup_setup_details_for_es_wait.txt` (pelias user level logs for es wait)
+* `/home/pelias/logs_pelias_setup_setup_details_for_es_create.txt` (pelias user level logs for es create)
+* `/home/pelias/logs_pelias_setup_setup_details_for_download.txt` (pelias user level logs for download)
+* `/home/pelias/logs_pelias_setup_setup_details_for_prepare.txt` (pelias user level logs for prepare)
+* `/home/pelias/logs_pelias_setup_setup_details_for_import.txt` (pelias user level logs for import)
+* `/home/pelias/logs_pelias_setup_setup_details_for_compose_up.txt` (pelias user level logs for compose up)
+
+## An example of how the script runs
+
+This script was tested on an Ubuntu 18.04 server from March 25th to April 8th 2019.
+
+Server specs:
+* 8 cores CPU: Intel(R) Xeon(R) CPU W3520 @ 2.67GHz
+* 32GB of RAM
+* 2TB of regular HDD (not SSD)
+
+Running the script gave this output for `./logs_pelias_setup.txt`:
+```
+Mon Mar 25 22:17:26 UTC 2019 - Step 1: install base dependencies
+Mon Mar 25 22:18:50 UTC 2019 - Step 2: configure nginx to redirect incoming https traffic to localhost:4000
+Mon Mar 25 22:18:50 UTC 2019 - Step 3: dedicated user creation
+Mon Mar 25 22:18:51 UTC 2019 - Step 4: pelias full setup as the user
+Sun Apr  7 14:04:47 UTC 2019 - Setup completed with success!!!
+```
+
+And it gave this output for `/home/pelias/logs_pelias_setup.txt`:
+```
+Mon Mar 25 22:18:51 UTC 2019 - User level setup - start
+Mon Mar 25 22:18:52 UTC 2019 - User level setup - compose file configuration
+Mon Mar 25 22:18:52 UTC 2019 - User level setup - compose pull
+Mon Mar 25 22:25:27 UTC 2019 - User level setup - elastic start
+Mon Mar 25 22:25:36 UTC 2019 - User level setup - elastic wait
+Mon Mar 25 22:25:44 UTC 2019 - User level setup - elastic create
+Mon Mar 25 22:25:51 UTC 2019 - User level setup - download all
+Tue Mar 26 00:27:07 UTC 2019 - User level setup - prepare all
+Thu Apr  4 11:39:58 UTC 2019 - User level setup - import all
+Sun Apr  7 14:03:46 UTC 2019 - User level setup - compose up
+Sun Apr  7 14:04:44 UTC 2019 - User level setup - Setup completed with success!!!
+```

--- a/tools/full_machine_setup_script/pelias_setup_main_as_root.sh
+++ b/tools/full_machine_setup_script/pelias_setup_main_as_root.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Exit on any error encountered
+set -e
+
+################################################################################
+# This script is meant to be run as root from a debian fresh install into
+# a screen (see 'screen' command).
+# It should allow you to setup your machine from a fresh install to a
+# production-ready pelias API.
+# This script will take DAYS to execute.
+################################################################################
+
+echo "$(date) - Step 1: install base dependencies">>~/logs_pelias_setup.txt
+################################################################################
+# Step 1: install base dependencies
+################################################################################
+apt-get update -qq
+apt-get install -y docker docker-compose nginx
+
+echo "$(date) - Step 2: configure nginx to redirect incoming https traffic to localhost:4000">>~/logs_pelias_setup.txt
+################################################################################
+# Step 2: configure nginx to redirect incoming https traffic to localhost:4000
+################################################################################
+export SERVER_DOMAIN_NAME="write.your.domain.here"
+echo "server {">/etc/nginx/sites-enabled/$SERVER_DOMAIN_NAME
+echo "  server_name $SERVER_DOMAIN_NAME;">>/etc/nginx/sites-enabled/$SERVER_DOMAIN_NAME
+echo "  location / {">>/etc/nginx/sites-enabled/$SERVER_DOMAIN_NAME
+echo "    proxy_pass http://localhost:4000;">>/etc/nginx/sites-enabled/$SERVER_DOMAIN_NAME
+echo "    proxy_set_header X-Real-IP \$remote_addr;">>/etc/nginx/sites-enabled/$SERVER_DOMAIN_NAME
+echo "  }">>/etc/nginx/sites-enabled/$SERVER_DOMAIN_NAME
+echo "}">>/etc/nginx/sites-enabled/$SERVER_DOMAIN_NAME
+service nginx restart
+
+echo "$(date) - Step 3: dedicated user creation">>~/logs_pelias_setup.txt
+################################################################################
+# Step 3: dedicated user creation
+################################################################################
+export USERNAME=pelias
+export USERHOME=/home/$USERNAME
+export PELIAS_PROJECT="planet"
+# Use this value instead if you want to test with a small dataset first
+#export PELIAS_PROJECT="portland-metro"
+export USER_SCRIPT_FILE_NAME="pelias_setup_user_level_part.sh"
+
+useradd -d $USERHOME -s /bin/bash -m $USERNAME
+usermod -G docker pelias
+chmod a+x $USERHOME
+
+echo "export USERNAME=$USERNAME">>$USERHOME/.bashrc
+echo "export USERHOME=$USERHOME">>$USERHOME/.bashrc
+echo "export PELIAS_PROJECT=$PELIAS_PROJECT">>$USERHOME/.bashrc
+
+cp ./$USER_SCRIPT_FILE_NAME $USERHOME/$USER_SCRIPT_FILE_NAME
+chown $USERNAME $USERHOME/$USER_SCRIPT_FILE_NAME
+chmod +x $USERHOME/$USER_SCRIPT_FILE_NAME
+
+echo "$(date) - Step 4: pelias full setup as the user">>~/logs_pelias_setup.txt
+################################################################################
+# Step 4: pelias full setup as the user
+################################################################################
+cd $USERHOME
+su $USERNAME -c "sh $USERHOME/$USER_SCRIPT_FILE_NAME"
+
+echo "$(date) - Setup completed with success!!!">>~/logs_pelias_setup.txt

--- a/tools/full_machine_setup_script/pelias_setup_user_level_part.sh
+++ b/tools/full_machine_setup_script/pelias_setup_user_level_part.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# Exit on any error encountered
+set -e
+
+echo "$(date) - User level setup - start">>~/logs_pelias_setup.txt
+cd $USERHOME
+
+# create directories
+mkdir code data bin
+
+# clone repo
+cd code
+git clone https://github.com/pelias/docker.git
+cd docker
+
+# install pelias command and add it to the user's PATH
+ln -s "$(pwd)/pelias" $USERHOME/bin/pelias
+echo "export PATH=\$PATH:$USERHOME/bin">>$USERHOME/.bashrc
+export PATH=$PATH:$USERHOME/bin
+
+# cwd to the pelias project dir
+cd $USERHOME/code/docker/projects/$PELIAS_PROJECT
+
+# create the env file as we want it
+echo "$(date) - User level setup - compose file configuration">>~/logs_pelias_setup.txt
+echo "COMPOSE_PROJECT_NAME=$USERNAME" > .env
+echo "DOCKER_USER=$(id -u $USERNAME)" >> .env
+echo "DATA_DIR=$USERHOME/data" >> .env
+
+# update the docker-compose.yml file to avoid exposing the ports publicly
+# this will result on external IP not having access to those ports
+# remove this step if you don't want to use a reverse proxy (nginx)
+sed -i 's/\"4000:4000\"/\"127.0.0.1:4000:4000\"/g' docker-compose.yml
+sed -i 's/\"4100:4100\"/\"127.0.0.1:4100:4100\"/g' docker-compose.yml
+sed -i 's/\"4200:4200\"/\"127.0.0.1:4200:4200\"/g' docker-compose.yml
+sed -i 's/\"4300:4300\"/\"127.0.0.1:4300:4300\"/g' docker-compose.yml
+sed -i 's/\"4400:4400\"/\"127.0.0.1:4400:4400\"/g' docker-compose.yml
+sed -i 's/\"9200:9200\"/\"127.0.0.1:9200:9200\"/g' docker-compose.yml
+sed -i 's/\"9300:9300\"/\"127.0.0.1:9300:9300\"/g' docker-compose.yml
+
+# Keep running the script even when facing errors, some of the following
+# commands can, return non 0 exit status even though they are fine
+# For example
+# "pelias prepare all"
+# can error out with
+# "tiger download dir does not exist"
+# even the overall setup is fine
+set +e
+
+# update all docker images
+echo "$(date) - User level setup - compose pull">>~/logs_pelias_setup.txt
+pelias compose pull 2>&1 | tee ~/logs_pelias_setup_setup_details_for_pull.txt
+
+# start elasticsearch server
+echo "$(date) - User level setup - elastic start">>~/logs_pelias_setup.txt
+pelias elastic start 2>&1 | tee ~/logs_pelias_setup_setup_details_for_es_start.txt
+
+# wait for elasticsearch to start up
+echo "$(date) - User level setup - elastic wait">>~/logs_pelias_setup.txt
+pelias elastic wait 2>&1 | tee ~/logs_pelias_setup_setup_details_for_es_wait.txt
+
+# create elasticsearch index with pelias mapping
+echo "$(date) - User level setup - elastic create">>~/logs_pelias_setup.txt
+pelias elastic create 2>&1 | tee ~/logs_pelias_setup_setup_details_for_es_create.txt
+
+# (re)download all data
+echo "$(date) - User level setup - download all">>~/logs_pelias_setup.txt
+pelias download all 2>&1 | tee ~/logs_pelias_setup_setup_details_for_download.txt
+
+# Hack to prevent that type of error from happening (from my experience of March 25, 2019):
+# --------------------------------------------------------------------------------
+# error: [dbclient-openstreetmap] [429] type=es_rejected_execution_exception, reason=rejected execution of
+# org.elasticsearch.transport.TransportService$4@2f587374 on EsThreadPoolExecutor[bulk, queue capacity = 50,
+# org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@74a68e1[Running, pool size = 8,
+# active threads = 8, queued tasks = 50, completed tasks = 30116]]
+# --------------------------------------------------------------------------------
+# See https://github.com/pelias/dbclient/issues/76
+curl -XPUT localhost:9200/_cluster/settings -d '{ "transient" : { "threadpool.bulk.queue_size" : 500 } }'
+
+# build all services which have a prepare step
+echo "$(date) - User level setup - prepare all">>~/logs_pelias_setup.txt
+pelias prepare all 2>&1 | tee ~/logs_pelias_setup_setup_details_for_prepare.txt
+
+# (re)import all data
+echo "$(date) - User level setup - import all">>~/logs_pelias_setup.txt
+pelias import all 2>&1 | tee ~/logs_pelias_setup_setup_details_for_import.txt
+
+# start one or more docker-compose service(s)
+echo "$(date) - User level setup - compose up">>~/logs_pelias_setup.txt
+pelias compose up 2>&1 | tee ~/logs_pelias_setup_setup_details_for_compose_up.txt
+
+echo "$(date) - User level setup - Setup completed with success!!!">>~/logs_pelias_setup.txt


### PR DESCRIPTION
Hey,

Trying to setup a single machine for a planet build, I would have loved to have a script to do everything in one shot without having to worry about forgetting any step.

This is the purpose of this script I wrote: Setup a single machine with a full planet data set.

Also, I wanted to have the API available on https and block http usage from external IPs so I added this to the setup script.

This will take the machine from a fresh install and perform all the steps to make the API up and running.

Note that this is a work in progress, so far there are still a few things missing:
- Given the important amount of time that it takes to setup the server (14 days in my case), I would like to use a VM snapshot that I can deploy to a server to get it up and running quickly, I'll probably add this to the script later
- The script needs to ignore errors from the pelias commands, I'm not sure if I'm doing things right, I would need some advice on that...

`pelias prepare all`
Tiger data dir not found error. Did I do something wrong? Ignoring this seems to not have consequences...

`pelias import all`
At one point, the import fails with errors like this one:
```
error: [dbclient-openstreetmap] [429] type=es_rejected_execution_exception, reason=rejected execution of
org.elasticsearch.transport.TransportService$4@2f587374 on EsThreadPoolExecutor[bulk, queue capacity = 50,
org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@74a68e1[Running, pool size = 8,
active threads = 8, queued tasks = 50, completed tasks = 30116]]
```
I worked around this with the following command:
`curl -XPUT localhost:9200/_cluster/settings -d '{ "transient" : { "threadpool.bulk.queue_size" : 500 } }'`

I was able to run the script and get the API up and running, but I'm looking for some feedback on what needs improvement there, maybe some obvious things I missed?