### PR TITLE
Warn if DATA_DIR is already set

### DIFF
--- a/lib/env.sh
+++ b/lib/env.sh
@@ -37,6 +37,8 @@ function env_load_stream(){
 # ensure locale is correctly set?
 # export LC_ALL=en_US.UTF-8
 
+# warn if DATA_DIR is already set
+[[ -n $DATA_DIR ]] && printf "DATA_DIR is already set to '$DATA_DIR' - this may cause the DATA_DIR specified in the .env to be ignored\n"
 # load DATA_DIR and other vars from docker-compose .env file
 # note: strips comments and empty lines
 [ -f .env ] && env_load_stream < <(grep -v '^$\|^\s*$\#' .env)

--- a/lib/env.sh
+++ b/lib/env.sh
@@ -24,6 +24,7 @@ function env_check(){
 # loads environment vars from a stream (such as a file)
 # example: env_load_stream < .env
 function env_load_stream(){
+  [[ -n $DATA_DIR ]] && printf "DATA_DIR is already set to '$DATA_DIR' - this may cause the DATA_DIR specified in the .env to be ignored\n"
   while IFS='=' read -r key value; do
     ([ -z $key ] || [ -z $value ]) && printf 'Invalid environment var "%s=%s"\n' $key $value && exit 1
     if [ -z ${!key} ]; then
@@ -37,8 +38,6 @@ function env_load_stream(){
 # ensure locale is correctly set?
 # export LC_ALL=en_US.UTF-8
 
-# warn if DATA_DIR is already set
-[[ -n $DATA_DIR ]] && printf "DATA_DIR is already set to '$DATA_DIR' - this may cause the DATA_DIR specified in the .env to be ignored\n"
 # load DATA_DIR and other vars from docker-compose .env file
 # note: strips comments and empty lines
 [ -f .env ] && env_load_stream < <(grep -v '^$\|^\s*$\#' .env)


### PR DESCRIPTION
If the variable DATA_DIR is already set the declaration of it via `.env` may be
ignored.

This prints only a warning rather than to unset the variable. Thus no documentation is broken, staying backward compatible.
It's interesting to debug the script like with `bash -x pelias prepare all` to see that there are *two values* for *one key* if the DATA_DIR is set as a variable (via `.env`) and outside of the `.env`.



Resolves #93.