### PR TITLE
Set default bulk queue size for ES 2.4 image

### DIFF
--- a/images/elasticsearch/2.4/Dockerfile
+++ b/images/elasticsearch/2.4/Dockerfile
@@ -4,3 +4,7 @@ FROM elasticsearch:2.4
 # configure plugins
 RUN /usr/share/elasticsearch/bin/plugin install analysis-icu
 RUN /usr/share/elasticsearch/bin/plugin install cloud-aws
+
+# elasticsearch config
+ADD elasticsearch.yml /usr/share/elasticsearch/config/
+RUN chown elasticsearch:elasticsearch config/elasticsearch.yml

--- a/images/elasticsearch/2.4/elasticsearch.yml
+++ b/images/elasticsearch/2.4/elasticsearch.yml
@@ -1,0 +1,8 @@
+bootstrap.memory_lock: true
+network.host: 0.0.0.0
+http.port: 9200
+node.master: true
+node.data: true
+threadpool:
+  bulk:
+    queue_size: 1000


### PR DESCRIPTION
Similar to https://github.com/pelias/docker/pull/71, its helpful to set the bulk import queue size to much larger than the default (50 for ES 2.4).

Without this setting, imports when running multiple importers can easily overwhelm Elasticsearch and fail.