### PR TITLE
Use ES5 for planet build

### DIFF
--- a/projects/planet/docker-compose.yml
+++ b/projects/planet/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch
+    image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
     restart: always
     environment: [ "ES_JAVA_OPTS=-Xmx8g" ]

--- a/projects/planet/pelias.json
+++ b/projects/planet/pelias.json
@@ -4,7 +4,7 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "2.4",
+    "apiVersion": "5.6",
     "hosts": [
       { "host": "elasticsearch" }
     ]


### PR DESCRIPTION
This is the last project not using ES5, and marks the completion of https://github.com/pelias/pelias/issues/461!

All our testing shows that ES5 performs well, with good query results and about 10% better throughput and 10% lower request latency.