### PR TITLE
Add the coutry France to WOF to get Bretagne Results

### DIFF
--- a/projects/france/pelias.json
+++ b/projects/france/pelias.json
@@ -61,7 +61,7 @@
       "datapath": "/data/whosonfirst",
       "importVenues": false,
       "importPostalcodes": true,
-      "importPlace": [ "136253037" ]
+      "importPlace": [ "136253037", "85633147" ]
     }
   }
 }


### PR DESCRIPTION
I added the France country id to wof because who's on first *France Empire* have no any result for the *Bretagne* Region 

This PR is to be able to retrieve all locality from Bretagne 

Fixes https://github.com/pelias/pelias/issues/798