### PR TITLE
Set DOCKER_USER for Elasticsearch as well.

### DIFF
--- a/projects/australia/docker-compose.yml
+++ b/projects/australia/docker-compose.yml
@@ -104,6 +104,7 @@ services:
   elasticsearch:
     image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
+    user: "${DOCKER_USER}"
     restart: always
     ports: [ "9200:9200", "9300:9300" ]
     volumes:

--- a/projects/belgium/docker-compose.yml
+++ b/projects/belgium/docker-compose.yml
@@ -94,6 +94,7 @@ services:
   elasticsearch:
     image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
+    user: "${DOCKER_USER}"
     restart: always
     ports: [ "9200:9200", "9300:9300" ]
     volumes:

--- a/projects/france/docker-compose.yml
+++ b/projects/france/docker-compose.yml
@@ -94,6 +94,7 @@ services:
   elasticsearch:
     image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
+    user: "${DOCKER_USER}"
     restart: always
     ports: [ "9200:9200", "9300:9300" ]
     volumes:

--- a/projects/jamaica/docker-compose.yml
+++ b/projects/jamaica/docker-compose.yml
@@ -104,6 +104,7 @@ services:
   elasticsearch:
     image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
+    user: "${DOCKER_USER}"
     restart: always
     ports: [ "9200:9200", "9300:9300" ]
     volumes:

--- a/projects/los-angeles-metro/docker-compose.yml
+++ b/projects/los-angeles-metro/docker-compose.yml
@@ -103,6 +103,7 @@ services:
   elasticsearch:
     image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
+    user: "${DOCKER_USER}"
     restart: always
     ports: [ "9200:9200", "9300:9300" ]
     volumes:

--- a/projects/north-america/docker-compose.yml
+++ b/projects/north-america/docker-compose.yml
@@ -90,6 +90,7 @@ services:
   elasticsearch:
     image: pelias/elasticsearch
     container_name: pelias_elasticsearch
+    user: "${DOCKER_USER}"
     restart: always
     environment: [ "ES_JAVA_OPTS=-Xmx8g" ]
     ports: [ "9200:9200", "9300:9300" ]

--- a/projects/planet/docker-compose.yml
+++ b/projects/planet/docker-compose.yml
@@ -112,6 +112,7 @@ services:
   elasticsearch:
     image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
+    user: "${DOCKER_USER}"
     restart: always
     environment: [ "ES_JAVA_OPTS=-Xmx8g" ]
     ports: [ "9200:9200", "9300:9300" ]

--- a/projects/san-jose-metro/docker-compose.yml
+++ b/projects/san-jose-metro/docker-compose.yml
@@ -103,6 +103,7 @@ services:
   elasticsearch:
     image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
+    user: "${DOCKER_USER}"
     restart: always
     ports: [ "9200:9200", "9300:9300" ]
     volumes:

--- a/projects/south-africa/docker-compose.yml
+++ b/projects/south-africa/docker-compose.yml
@@ -111,6 +111,7 @@ services:
   elasticsearch:
     image: pelias/elasticsearch:5.6.12
     container_name: pelias_elasticsearch
+    user: "${DOCKER_USER}"
     restart: always
     ports: [ "9200:9200", "9300:9300" ]
     volumes:


### PR DESCRIPTION
I encountered permission errors with the ES container and debugging I noticed that the user var was not passed. This fixes it.

Context: https://github.com/pelias/docker#variable-docker_user