### PR TITLE
feat(elasticsearch-5): Remove X-Pack extension

### DIFF
--- a/images/elasticsearch/5.6.12/Dockerfile
+++ b/images/elasticsearch/5.6.12/Dockerfile
@@ -6,12 +6,13 @@ USER root
 
 # environmental settings
 ENV ES_JAVA_OPTS '-Xms512m -Xmx512m'
-ENV xpack.security.enabled 'false'
-ENV xpack.monitoring.enabled 'false'
 ENV cluster.name 'pelias-dev'
 ENV discovery.type 'single-node'
 ENV bootstrap.memory_lock 'true'
 RUN echo 'vm.max_map_count=262144' >> /etc/sysctl.conf
+
+# disable xpack
+RUN /usr/share/elasticsearch/bin/elasticsearch-plugin remove x-pack --purge
 
 # configure plugins
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu
@@ -31,7 +32,6 @@ RUN chmod go+w /usr/share/elasticsearch \
 RUN chmod go+x /usr/share/elasticsearch \
     /usr/share/elasticsearch/config \
 	/usr/share/elasticsearch/config/ingest-geoip \
-	/usr/share/elasticsearch/config/x-pack \
 	/usr/share/elasticsearch/config/repository-s3
 # add execute permissions to bins
 RUN chmod go+x /usr/share/elasticsearch/bin/*

--- a/images/elasticsearch/5.6.12/elasticsearch.yml
+++ b/images/elasticsearch/5.6.12/elasticsearch.yml
@@ -1,4 +1,3 @@
-xpack.security.enabled: false
 bootstrap.memory_lock: true
 network.host: 0.0.0.0
 http.port: 9200


### PR DESCRIPTION
The X-Pack extensions to Elasticsearch are proprietary addons for
additional functionality, none of which is needed by Pelias.

In the past, we've made due with disabling some of them by environment
variable, however that still leaves them present to emit scary warnings
about licenses. These warnings probably are ok to ignore, again since
Pelias does not use any X-Pack features.

However, its best to avoid scary warnings where possible, so this change
removes the X-Pack plugin completely.

Fixes https://github.com/pelias/docker/issues/110