### PR TITLE
Add Elasticsearch 7.4.0 Docker image

### DIFF
--- a/images/elasticsearch/7.4.0/Dockerfile
+++ b/images/elasticsearch/7.4.0/Dockerfile
@@ -1,0 +1,36 @@
+# see: https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
+
+# base image
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.4.0
+USER root
+
+# environmental settings
+ENV ES_JAVA_OPTS '-Xms512m -Xmx512m'
+ENV cluster.name 'pelias-dev'
+ENV discovery.type 'single-node'
+ENV bootstrap.memory_lock 'true'
+RUN echo 'vm.max_map_count=262144' >> /etc/sysctl.conf
+
+# configure plugins
+RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu
+RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install repository-s3 --batch
+
+# elasticsearch config
+ADD elasticsearch.yml /usr/share/elasticsearch/config/
+RUN chown elasticsearch:elasticsearch config/elasticsearch.yml
+
+## set permissions so any user can run elasticsearch
+# add read permissions to all files in dir
+RUN chmod go+r /usr/share/elasticsearch -R
+# add write permissions to config dir
+RUN chmod go+w /usr/share/elasticsearch \
+    /usr/share/elasticsearch/config
+# add list permissions to directorys
+RUN chmod go+x /usr/share/elasticsearch \
+    /usr/share/elasticsearch/config \
+	/usr/share/elasticsearch/config/repository-s3
+# add execute permissions to bins
+RUN chmod go+x /usr/share/elasticsearch/bin/*
+
+# run as elasticsearch user
+USER elasticsearch

--- a/images/elasticsearch/7.4.0/elasticsearch.yml
+++ b/images/elasticsearch/7.4.0/elasticsearch.yml
@@ -1,0 +1,8 @@
+bootstrap.memory_lock: true
+network.host: 0.0.0.0
+http.port: 9200
+node.master: true
+node.data: true
+thread_pool:
+  write:
+    queue_size: 1000


### PR DESCRIPTION
This is the first step in supporting Elasticsearch 7.

At this time, Pelias does not work out of the box on ES7, but with a Docker image ready to go, we can begin testing changes for compatibility.

This Dockerfile and config is identical to the ES6 Docker image, except for changing the version, and making one update to the `elasticsearch.yml`:

In ES7, the bulk thread pool is removed, and both bulk and non-bulk operations go through a single
[write](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-threadpool.html#modules-threadpool) thread pool.

For Pelias we have found increasing the queue size of this thread pool is useful to ensure imports can succeed without errors, so the configuration file has been updated accordingly.

Connects https://github.com/pelias/pelias/issues/831