### PR TITLE
update pelias.json settings in order to produce ES indices compatible with versions 6+7

### DIFF
--- a/projects/australia/pelias.json
+++ b/projects/australia/pelias.json
@@ -9,6 +9,9 @@
       { "host": "elasticsearch" }
     ]
   },
+  "schema": {
+    "typeName": "_doc"
+  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/belgium/pelias.json
+++ b/projects/belgium/pelias.json
@@ -9,6 +9,9 @@
       { "host": "elasticsearch" }
     ]
   },
+  "schema": {
+    "typeName": "_doc"
+  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/brazil/pelias.json
+++ b/projects/brazil/pelias.json
@@ -9,6 +9,9 @@
       { "host": "elasticsearch" }
     ]
   },
+  "schema": {
+    "typeName": "_doc"
+  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/france/pelias.json
+++ b/projects/france/pelias.json
@@ -9,6 +9,9 @@
       { "host": "elasticsearch" }
     ]
   },
+  "schema": {
+    "typeName": "_doc"
+  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/jamaica/pelias.json
+++ b/projects/jamaica/pelias.json
@@ -9,6 +9,9 @@
       { "host": "elasticsearch" }
     ]
   },
+  "schema": {
+    "typeName": "_doc"
+  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/los-angeles-metro/pelias.json
+++ b/projects/los-angeles-metro/pelias.json
@@ -9,6 +9,9 @@
       { "host": "elasticsearch" }
     ]
   },
+  "schema": {
+    "typeName": "_doc"
+  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/netherlands/pelias.json
+++ b/projects/netherlands/pelias.json
@@ -9,6 +9,9 @@
       { "host": "elasticsearch" }
     ]
   },
+  "schema": {
+    "typeName": "_doc"
+  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/north-america/pelias.json
+++ b/projects/north-america/pelias.json
@@ -8,6 +8,9 @@
       { "host": "elasticsearch" }
     ]
   },
+  "schema": {
+    "typeName": "_doc"
+  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/planet/pelias.json
+++ b/projects/planet/pelias.json
@@ -9,6 +9,9 @@
       { "host": "elasticsearch" }
     ]
   },
+  "schema": {
+    "typeName": "_doc"
+  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/portland-metro/pelias.json
+++ b/projects/portland-metro/pelias.json
@@ -9,6 +9,9 @@
       { "host": "elasticsearch" }
     ]
   },
+  "schema": {
+    "typeName": "_doc"
+  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/san-jose-metro/pelias.json
+++ b/projects/san-jose-metro/pelias.json
@@ -9,6 +9,9 @@
       { "host": "elasticsearch" }
     ]
   },
+  "schema": {
+    "typeName": "_doc"
+  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/singapore/pelias.json
+++ b/projects/singapore/pelias.json
@@ -9,6 +9,9 @@
       { "host": "elasticsearch" }
     ]
   },
+  "schema": {
+    "typeName": "_doc"
+  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/south-africa/pelias.json
+++ b/projects/south-africa/pelias.json
@@ -9,6 +9,9 @@
       { "host": "elasticsearch" }
     ]
   },
+  "schema": {
+    "typeName": "_doc"
+  },
   "elasticsearch": {
     "settings": {
       "index": {


### PR DESCRIPTION
following on from https://github.com/pelias/docker/pull/144 this PR updates `pelias.json` settings in order to produce ES indices compatible with versions 6 & 7

in order to continue supporting elasticsearch@5 during our deprecation window, we are still using the type name "doc" by default.
using "doc" ensures **forward** compatibility between elasticsearch versions 5 & 6, but does not work with 7.

since the configs here are already set to build on version 6 (which isn't **backwards** compatible with 5), we can use this setting to ensure that new indices built are done using the type named "_doc" (note the underscore).

this will ensure that indices are compatible with 6 & 7 and that users building after this change will not suffer from the breaking change introduced by a type name change at a later date 🎉 

please ensure you `pelias compose pull` the latest images before running an import as I only updated them today!

pairs with https://github.com/pelias/schema/pull/401