### PR TITLE
elasticsearch 6 image fails to start when custom groups used

### DIFF
--- a/images/elasticsearch/6.8.5/Dockerfile
+++ b/images/elasticsearch/6.8.5/Dockerfile
@@ -22,13 +22,18 @@ RUN chown elasticsearch:elasticsearch config/elasticsearch.yml
 ## set permissions so any user can run elasticsearch
 # add read permissions to all files in dir
 RUN chmod go+r /usr/share/elasticsearch -R
-# add write permissions to config dir
+
+# add write permissions to config, log & data dirs
 RUN chmod go+w /usr/share/elasticsearch \
-    /usr/share/elasticsearch/config
-# add list permissions to directorys
+  /usr/share/elasticsearch/config \
+  /usr/share/elasticsearch/logs \
+  /usr/share/elasticsearch/data
+
+# add list permissions to directories
 RUN chmod go+x /usr/share/elasticsearch \
-    /usr/share/elasticsearch/config \
-	/usr/share/elasticsearch/config/repository-s3
+  /usr/share/elasticsearch/config \
+  /usr/share/elasticsearch/config/repository-s3
+
 # add execute permissions to bins
 RUN chmod go+x /usr/share/elasticsearch/bin/*
 

--- a/images/elasticsearch/7.4.2/Dockerfile
+++ b/images/elasticsearch/7.4.2/Dockerfile
@@ -22,13 +22,18 @@ RUN chown elasticsearch:elasticsearch config/elasticsearch.yml
 ## set permissions so any user can run elasticsearch
 # add read permissions to all files in dir
 RUN chmod go+r /usr/share/elasticsearch -R
-# add write permissions to config dir
+
+# add write permissions to config, log & data dirs
 RUN chmod go+w /usr/share/elasticsearch \
-    /usr/share/elasticsearch/config
-# add list permissions to directorys
+  /usr/share/elasticsearch/config \
+  /usr/share/elasticsearch/logs \
+  /usr/share/elasticsearch/data
+
+# add list permissions to directories
 RUN chmod go+x /usr/share/elasticsearch \
-    /usr/share/elasticsearch/config \
-	/usr/share/elasticsearch/config/repository-s3
+  /usr/share/elasticsearch/config \
+  /usr/share/elasticsearch/config/repository-s3
+
 # add execute permissions to bins
 RUN chmod go+x /usr/share/elasticsearch/bin/*
 


### PR DESCRIPTION
This issue came in yesterday via a Geocode Earth support request.

When customizing the `user:group` settings using the env var `DOCKER_USER=` the new `pelias/elasticsearch:6.8.5` image fails to start due to permission errors.

More accurately it works fine if only specifying a `user` such as `DOCKER_USER=500` but fails when specifying a `group` such as `DOCKER_USER=500:500`.

The issue can be reproduced with the following command:
```bash
docker run --rm -it -u 500:500 pelias/elasticsearch:6.8.5
```

This PR updates permissions on the `./logs` and `./data` directories as not having write permission on either of these directories will cause a fatal error upon boot.