### PR TITLE
Update LACMTA gtfs_rail URL. Fixes #152.

### DIFF
--- a/projects/los-angeles-metro/pelias.json
+++ b/projects/los-angeles-metro/pelias.json
@@ -95,7 +95,7 @@
         },
         {
           "layerId": "stops",
-          "url": "https://gitlab.com/LACMTA/gtfs_bus/raw/master/gtfs_rail.zip",
+          "url": "https://gitlab.com/LACMTA/gtfs_rail/raw/master/gtfs_rail.zip",
           "filename": "stops.txt",
           "agencyId": "LA Metro",
           "agencyName": "LA Metro",


### PR DESCRIPTION
---
#### Here's the reason for this change :rocket:

When downloading data in the `los-angeles-metro` project, the attempt to download gtfs_rail.zip fails (#152).

---
#### Here's what actually got changed :clap:

Changed the URL to reference the new github repo that now contains gtfs_rail.zip.

---

#### Here's how others can test the changes :eyes:

`pelias download all` should now download gtfs_rail.zip without error.

