### PR TITLE
docs(readme): link to docker and docker-compose changelogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Once you have successfully completed a small build you can use this as a base to
 
 ## Prerequisites
 
-You will need to have `docker` and `docker-compose` installed before continuing. If you are not using the latest version, please mention that in any bugs reports.
+You will need to have a [modern version of `docker`](https://docs.docker.com/engine/release-notes/) and a [modern version of `docker-compose`](https://github.com/docker/compose/blob/master/CHANGELOG.md) installed before continuing. If you are not using the latest version, please mention that in any bugs reports.
 
 This project supports Linux and Mac OSX operatings systems. Windows is currently [not supported](https://github.com/pelias/docker/issues/124).
 


### PR DESCRIPTION
we've had a couple of reports that our `docker-compose.yml` files don't work on older versions of `docker-compose`.
this PR updates the prerequisites documentation slightly to indicate that a "modern" version is required.

I'm not sure exactly which minimum versions are required, so the general advice is to use something that existed at the time the code/config which it's consuming was written.

related: https://github.com/pelias/docker/issues/155, https://github.com/pelias/docker/issues/2