### PR TITLE
Remove typeName configuration option

### DIFF
--- a/projects/australia/pelias.json
+++ b/projects/australia/pelias.json
@@ -9,9 +9,6 @@
       { "host": "elasticsearch" }
     ]
   },
-  "schema": {
-    "typeName": "_doc"
-  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/belgium/pelias.json
+++ b/projects/belgium/pelias.json
@@ -9,9 +9,6 @@
       { "host": "elasticsearch" }
     ]
   },
-  "schema": {
-    "typeName": "_doc"
-  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/brazil/pelias.json
+++ b/projects/brazil/pelias.json
@@ -9,9 +9,6 @@
       { "host": "elasticsearch" }
     ]
   },
-  "schema": {
-    "typeName": "_doc"
-  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/france/pelias.json
+++ b/projects/france/pelias.json
@@ -9,9 +9,6 @@
       { "host": "elasticsearch" }
     ]
   },
-  "schema": {
-    "typeName": "_doc"
-  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/jamaica/pelias.json
+++ b/projects/jamaica/pelias.json
@@ -9,9 +9,6 @@
       { "host": "elasticsearch" }
     ]
   },
-  "schema": {
-    "typeName": "_doc"
-  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/los-angeles-metro/pelias.json
+++ b/projects/los-angeles-metro/pelias.json
@@ -9,9 +9,6 @@
       { "host": "elasticsearch" }
     ]
   },
-  "schema": {
-    "typeName": "_doc"
-  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/netherlands/pelias.json
+++ b/projects/netherlands/pelias.json
@@ -9,9 +9,6 @@
       { "host": "elasticsearch" }
     ]
   },
-  "schema": {
-    "typeName": "_doc"
-  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/north-america/pelias.json
+++ b/projects/north-america/pelias.json
@@ -9,9 +9,6 @@
       { "host": "elasticsearch" }
     ]
   },
-  "schema": {
-    "typeName": "_doc"
-  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/planet/pelias.json
+++ b/projects/planet/pelias.json
@@ -9,9 +9,6 @@
       { "host": "elasticsearch" }
     ]
   },
-  "schema": {
-    "typeName": "_doc"
-  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/portland-metro/pelias.json
+++ b/projects/portland-metro/pelias.json
@@ -9,9 +9,6 @@
       { "host": "elasticsearch" }
     ]
   },
-  "schema": {
-    "typeName": "_doc"
-  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/san-jose-metro/pelias.json
+++ b/projects/san-jose-metro/pelias.json
@@ -9,9 +9,6 @@
       { "host": "elasticsearch" }
     ]
   },
-  "schema": {
-    "typeName": "_doc"
-  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/singapore/pelias.json
+++ b/projects/singapore/pelias.json
@@ -9,9 +9,6 @@
       { "host": "elasticsearch" }
     ]
   },
-  "schema": {
-    "typeName": "_doc"
-  },
   "elasticsearch": {
     "settings": {
       "index": {

--- a/projects/south-africa/pelias.json
+++ b/projects/south-africa/pelias.json
@@ -9,9 +9,6 @@
       { "host": "elasticsearch" }
     ]
   },
-  "schema": {
-    "typeName": "_doc"
-  },
   "elasticsearch": {
     "settings": {
       "index": {


### PR DESCRIPTION
Now that we have merged https://github.com/pelias/config/pull/122 and associated PRs to add Elasticsearch 7 support to Pelias master branches, we no longer need to override the `typeName` config option in project `pelias.json` configration.

This reverts commit acc4202eee969e315dac82d2e775e87b03101f91.

Connects https://github.com/pelias/pelias/issues/831
