### PR TITLE
Use Elasticsearch 7.5.1 across all projects

### DIFF
--- a/projects/australia/docker-compose.yml
+++ b/projects/australia/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:6.8.5
+    image: pelias/elasticsearch:7.5.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/australia/pelias.json
+++ b/projects/australia/pelias.json
@@ -4,7 +4,7 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "6.8",
+    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/belgium/docker-compose.yml
+++ b/projects/belgium/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:6.8.5
+    image: pelias/elasticsearch:7.5.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/belgium/pelias.json
+++ b/projects/belgium/pelias.json
@@ -4,7 +4,7 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "6.8",
+    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/brazil/docker-compose.yml
+++ b/projects/brazil/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:6.8.5
+    image: pelias/elasticsearch:7.5.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/brazil/pelias.json
+++ b/projects/brazil/pelias.json
@@ -4,7 +4,7 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "6.8",
+    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/france/docker-compose.yml
+++ b/projects/france/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:6.8.5
+    image: pelias/elasticsearch:7.5.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/france/pelias.json
+++ b/projects/france/pelias.json
@@ -4,7 +4,7 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "6.8",
+    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/jamaica/docker-compose.yml
+++ b/projects/jamaica/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:6.8.5
+    image: pelias/elasticsearch:7.5.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/jamaica/pelias.json
+++ b/projects/jamaica/pelias.json
@@ -4,7 +4,7 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "6.8",
+    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/los-angeles-metro/docker-compose.yml
+++ b/projects/los-angeles-metro/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:6.8.5
+    image: pelias/elasticsearch:7.5.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/los-angeles-metro/pelias.json
+++ b/projects/los-angeles-metro/pelias.json
@@ -4,7 +4,7 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "6.8",
+    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/netherlands/docker-compose.yml
+++ b/projects/netherlands/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:6.8.5
+    image: pelias/elasticsearch:7.5.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/netherlands/pelias.json
+++ b/projects/netherlands/pelias.json
@@ -4,7 +4,7 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "6.8",
+    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/north-america/docker-compose.yml
+++ b/projects/north-america/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:6.8.5
+    image: pelias/elasticsearch:7.5.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/north-america/pelias.json
+++ b/projects/north-america/pelias.json
@@ -4,7 +4,7 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "6.8",
+    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/planet/docker-compose.yml
+++ b/projects/planet/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:6.8.5
+    image: pelias/elasticsearch:7.5.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/planet/pelias.json
+++ b/projects/planet/pelias.json
@@ -4,7 +4,7 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "6.8",
+    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:6.8.5
+    image: pelias/elasticsearch:7.5.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/portland-metro/pelias.json
+++ b/projects/portland-metro/pelias.json
@@ -4,7 +4,7 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "6.8",
+    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/san-jose-metro/docker-compose.yml
+++ b/projects/san-jose-metro/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:6.8.5
+    image: pelias/elasticsearch:7.5.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/san-jose-metro/pelias.json
+++ b/projects/san-jose-metro/pelias.json
@@ -4,7 +4,7 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "6.8",
+    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/singapore/docker-compose.yml
+++ b/projects/singapore/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:6.8.5
+    image: pelias/elasticsearch:7.5.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/singapore/pelias.json
+++ b/projects/singapore/pelias.json
@@ -4,7 +4,7 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "6.8",
+    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/south-africa/docker-compose.yml
+++ b/projects/south-africa/docker-compose.yml
@@ -109,7 +109,7 @@ services:
     volumes:
       - "../../common/preview:/usr/share/nginx/html"
   elasticsearch:
-    image: pelias/elasticsearch:6.8.5
+    image: pelias/elasticsearch:7.5.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/south-africa/pelias.json
+++ b/projects/south-africa/pelias.json
@@ -4,7 +4,7 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "6.8",
+    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]


### PR DESCRIPTION
We've done a lot of testing on ES7 and are now pretty confident that it can be rolled out to all projects, which will help us gather even more data about how well it works.

Connects https://github.com/pelias/pelias/issues/831