### PR TITLE
fix(pelias.json): remove explicit esclient.apiVersion from projects

### DIFF
--- a/projects/australia/pelias.json
+++ b/projects/australia/pelias.json
@@ -4,7 +4,6 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/belgium/pelias.json
+++ b/projects/belgium/pelias.json
@@ -4,7 +4,6 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/brazil/pelias.json
+++ b/projects/brazil/pelias.json
@@ -4,7 +4,6 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/france/pelias.json
+++ b/projects/france/pelias.json
@@ -4,7 +4,6 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/jamaica/pelias.json
+++ b/projects/jamaica/pelias.json
@@ -4,7 +4,6 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/los-angeles-metro/pelias.json
+++ b/projects/los-angeles-metro/pelias.json
@@ -4,7 +4,6 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/netherlands/pelias.json
+++ b/projects/netherlands/pelias.json
@@ -4,7 +4,6 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/north-america/pelias.json
+++ b/projects/north-america/pelias.json
@@ -4,7 +4,6 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/planet/pelias.json
+++ b/projects/planet/pelias.json
@@ -4,7 +4,6 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/portland-metro/pelias.json
+++ b/projects/portland-metro/pelias.json
@@ -4,7 +4,6 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/san-jose-metro/pelias.json
+++ b/projects/san-jose-metro/pelias.json
@@ -4,7 +4,6 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/singapore/pelias.json
+++ b/projects/singapore/pelias.json
@@ -4,7 +4,6 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]

--- a/projects/south-africa/pelias.json
+++ b/projects/south-africa/pelias.json
@@ -4,7 +4,6 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "7.5",
     "hosts": [
       { "host": "elasticsearch" }
     ]


### PR DESCRIPTION
once [this PR lands](https://github.com/pelias/schema/issues/435) all the projects are going to break for the [same reason as this Travis run failed](https://travis-ci.org/github/pelias/schema/builds/667038660?utm_source=github_status&utm_medium=notification).

we've got two options, either:
- change all the `esclient.apiVersion` blocks to `7.6` or `7.x`
- remove them all and rely on the default `pelias/config` value.

I chose the latter because it simplifies the configs.

This relies on https://github.com/pelias/config/pull/126 to be merged first!