### PR TITLE
disable TTY for prepare scripts to avoid unsightly buffering

### DIFF
--- a/cmd/prepare.sh
+++ b/cmd/prepare.sh
@@ -2,11 +2,11 @@
 set -e;
 
 # per-source prepares
-function prepare_polylines(){ compose_run 'polylines' bash ./docker_extract.sh; }
-function prepare_interpolation(){ compose_run 'interpolation' bash ./docker_build.sh; }
+function prepare_polylines(){ compose_run -T 'polylines' bash ./docker_extract.sh; }
+function prepare_interpolation(){ compose_run -T 'interpolation' bash ./docker_build.sh; }
 function prepare_placeholder(){
-  compose_run 'placeholder' ./cmd/extract.sh;
-  compose_run 'placeholder' ./cmd/build.sh;
+  compose_run -T 'placeholder' ./cmd/extract.sh;
+  compose_run -T 'placeholder' ./cmd/build.sh;
 }
 
 register 'prepare' 'polylines' 'export road network from openstreetmap into polylines format' prepare_polylines


### PR DESCRIPTION
disable TTY for prepare scripts to avoid unsightly buffering

<img width="716" alt="Screenshot 2020-03-30 at 18 25 42" src="https://user-images.githubusercontent.com/738069/77946877-547eb280-72c3-11ea-98ac-ab0702b94609.png">


<img width="716" alt="Screenshot 2020-03-30 at 18 36 21" src="https://user-images.githubusercontent.com/738069/77946888-5779a300-72c3-11ea-8899-3dbf2c17582c.png">
