### PR TITLE
disable TTY for prepeare scripts to avoid unsightly buffering

### DIFF
--- a/cmd/download.sh
+++ b/cmd/download.sh
@@ -2,13 +2,13 @@
 set -e;
 
 # per-source downloads
-function download_wof(){ compose_run 'whosonfirst' './bin/download'; }
-function download_oa(){ compose_run 'openaddresses' './bin/download'; }
-function download_osm(){ compose_run 'openstreetmap' './bin/download'; }
-function download_geonames(){ compose_run 'geonames' './bin/download'; }
-function download_tiger(){ compose_run 'interpolation' './bin/download-tiger'; }
-function download_transit(){ compose_run 'transit' './bin/download'; }
-function download_csv(){ compose_run 'csv-importer' './bin/download'; }
+function download_wof(){ compose_run -T 'whosonfirst' './bin/download'; }
+function download_oa(){ compose_run -T 'openaddresses' './bin/download'; }
+function download_osm(){ compose_run -T 'openstreetmap' './bin/download'; }
+function download_geonames(){ compose_run -T 'geonames' './bin/download'; }
+function download_tiger(){ compose_run -T 'interpolation' './bin/download-tiger'; }
+function download_transit(){ compose_run -T 'transit' './bin/download'; }
+function download_csv(){ compose_run -T 'csv-importer' './bin/download'; }
 
 register 'download' 'wof' '(re)download whosonfirst data' download_wof
 register 'download' 'oa' '(re)download openaddresses data' download_oa


### PR DESCRIPTION
following on from https://github.com/pelias/docker/pull/184 this PR fixes the same thing for the `download all` command