### PR TITLE
Add `countryCode` property to WOF configuration

### DIFF
--- a/projects/australia/pelias.json
+++ b/projects/australia/pelias.json
@@ -61,7 +61,7 @@
     },
     "whosonfirst": {
       "datapath": "/data/whosonfirst",
-      "importVenues": false,
+      "countryCode": "AU",
       "importPostalcodes": true,
       "importPlace": [
         "85632793"

--- a/projects/belgium/pelias.json
+++ b/projects/belgium/pelias.json
@@ -58,7 +58,7 @@
     },
     "whosonfirst": {
       "datapath": "/data/whosonfirst",
-      "importVenues": false,
+      "countryCode": "BE",
       "importPostalcodes": true,
       "importPlace": [ "85632997" ]
     }

--- a/projects/brazil/pelias.json
+++ b/projects/brazil/pelias.json
@@ -87,7 +87,7 @@
     },
     "whosonfirst": {
       "datapath": "/data/whosonfirst",
-      "importVenues": true,
+      "countryCode": "BR",
       "importPostalcodes": true,
       "importPlace": [
         "85633009"

--- a/projects/france/pelias.json
+++ b/projects/france/pelias.json
@@ -58,8 +58,8 @@
     },
     "whosonfirst": {
       "datapath": "/data/whosonfirst",
-      "importVenues": false,
       "importPostalcodes": true,
+      "countryCode": "FR",
       "importPlace": [ "136253037", "85633147" ]
     }
   }

--- a/projects/jamaica/pelias.json
+++ b/projects/jamaica/pelias.json
@@ -61,7 +61,7 @@
     },
     "whosonfirst": {
       "datapath": "/data/whosonfirst",
-      "importVenues": true,
+      "countryCode": "JM",
       "importPostalcodes": true,
       "importPlace": [
         "85632215"

--- a/projects/los-angeles-metro/pelias.json
+++ b/projects/los-angeles-metro/pelias.json
@@ -41,7 +41,7 @@
     },
     "geonames": {
       "datapath": "/data/geonames",
-      "countryCode": "ALL"
+      "countryCode": "US"
     },
     "openstreetmap": {
       "download": [
@@ -67,6 +67,7 @@
       "datapath": "/data/whosonfirst",
       "importVenues": false,
       "importPostalcodes": true,
+      "countryCode": "US",
       "importPlace": [
         "102086957"
       ]

--- a/projects/netherlands/pelias.json
+++ b/projects/netherlands/pelias.json
@@ -58,7 +58,7 @@
     },
     "whosonfirst": {
       "datapath": "/data/whosonfirst",
-      "importVenues": false,
+      "countryCode": "NL",
       "importPostalcodes": true,
       "importPlace": [ "85633337" ]
     }

--- a/projects/north-america/pelias.json
+++ b/projects/north-america/pelias.json
@@ -1833,6 +1833,7 @@
     "whosonfirst": {
       "datapath": "/data/whosonfirst",
       "importPostalcodes": true,
+      "countryCode": ["CA", "MX", "US"],
       "importPlace": "102191575"
     },
     "interpolation": {

--- a/projects/north-america/pelias.json
+++ b/projects/north-america/pelias.json
@@ -1833,7 +1833,8 @@
     "whosonfirst": {
       "datapath": "/data/whosonfirst",
       "importPostalcodes": true,
-      "countryCode": ["CA", "MX", "US"],
+      "countryCode": ["AI", "AG", "AW", "BS", "BB", "BZ", "BM", "BQ", "BO", "VG", "KY", "CA",
+        "CR", "CU", "CW", "DM", "DO", "SV", "GD", "GL", "GT", "HT", "HN", "JM", "MQ", "MS", "NI", "VE", "PA", "PR", "BL", "KN", "LC", "PM", "VC", "SX", "MF", "MX", "TT", "TC", "US", "VI"],
       "importPlace": "102191575"
     },
     "interpolation": {

--- a/projects/planet/pelias.json
+++ b/projects/planet/pelias.json
@@ -60,7 +60,6 @@
     },
     "whosonfirst": {
       "datapath": "/data/whosonfirst",
-      "importVenues": false,
       "importPostalcodes": true
     },
     "interpolation": {

--- a/projects/portland-metro/pelias.json
+++ b/projects/portland-metro/pelias.json
@@ -85,6 +85,7 @@
       "datapath": "/data/whosonfirst",
       "importVenues": false,
       "importPostalcodes": true,
+      "countryCode": "US",
       "importPlace": [
         "85688513",
         "85688623"

--- a/projects/san-jose-metro/pelias.json
+++ b/projects/san-jose-metro/pelias.json
@@ -41,7 +41,7 @@
     },
     "geonames": {
       "datapath": "/data/geonames",
-      "countryCode": "ALL"
+      "countryCode": "US"
     },
     "openstreetmap": {
       "download": [
@@ -71,8 +71,8 @@
     },
     "whosonfirst": {
       "datapath": "/data/whosonfirst",
-      "importVenues": false,
       "importPostalcodes": true,
+      "countryCode": "US",
       "importPlace": [
         "1360665447"
       ]

--- a/projects/singapore/pelias.json
+++ b/projects/singapore/pelias.json
@@ -60,10 +60,9 @@
       "files": [ "extract.0sv" ]
     },
     "whosonfirst": {
-      "sqlite": true,
       "datapath": "/data/whosonfirst",
-      "importVenues": false,
       "importPostalcodes": true,
+      "countryCode": "SG",
       "importPlace": [
         "85632605"
       ]

--- a/projects/south-africa/pelias.json
+++ b/projects/south-africa/pelias.json
@@ -65,8 +65,8 @@
     },
     "whosonfirst": {
       "datapath": "/data/whosonfirst",
-      "importVenues": false,
       "importPostalcodes": true,
+      "countryCode": "ZA",
       "importPlace": [
         "85633813"
       ]

--- a/projects/south-america/pelias.json
+++ b/projects/south-america/pelias.json
@@ -93,8 +93,8 @@
     },
     "whosonfirst": {
       "datapath": "/data/whosonfirst",
-      "importVenues": true,
       "importPostalcodes": true,
+      "countryCode": [ "AR", "BO", "BR", "CL", "GF", "EC", "GY", "PY", "PE", "SR", "UY", "VE" ],
       "importPlace": [
         "102191577"
       ]


### PR DESCRIPTION
Now that the Who's on First downloader defaults to using SQLite downloads and supports country-specific bundles thanks to https://github.com/pelias/whosonfirst/pull/487, we can start using that new functionality.

This PR sets the `imports.whosonfirst.countryCode` property appropriately across all our current projects.

This should not only help make all imports quite a bit faster, but it will require much less disk space for everyone!

Since we're now sponsoring the Who's on First downloads here at Geocode Earth, the bandwidth savings also make us happy :)

Along the way I made a few minor changes to remove some deprecated config options like `importVenues` and `sqlite`.