### PR TITLE
fix(pelias.json): remove whosonfirst.importVenues from projects

### DIFF
--- a/projects/los-angeles-metro/pelias.json
+++ b/projects/los-angeles-metro/pelias.json
@@ -65,7 +65,6 @@
     },
     "whosonfirst": {
       "datapath": "/data/whosonfirst",
-      "importVenues": false,
       "importPostalcodes": true,
       "countryCode": "US",
       "importPlace": [

--- a/projects/portland-metro/pelias.json
+++ b/projects/portland-metro/pelias.json
@@ -83,7 +83,6 @@
     },
     "whosonfirst": {
       "datapath": "/data/whosonfirst",
-      "importVenues": false,
       "importPostalcodes": true,
       "countryCode": "US",
       "importPlace": [


### PR DESCRIPTION
Projects with `whosonfirst.importVenues` on `pelias.config` are falling with: 

```
Error: "imports.whosonfirst.importVenues" is not allowed
```

I believe it's related to https://github.com/pelias/config/pull/128.

This PR removes `whosonfirst.importVenues` from _portland-metro_ and _los-angeles-metro_ projects.
