### PR TITLE
print a helpful error message if docker memory is too low

### DIFF
--- a/cmd/prepare.sh
+++ b/cmd/prepare.sh
@@ -1,8 +1,21 @@
 #!/bin/bash
 set -e;
 
+function check_docker_memory(){
+  DOCKER_TOTAL_MEMORY=`docker info | grep "Total Memory" | awk -F' ' '{print $3;}'`;
+  if [ -z "${DOCKER_TOTAL_MEMORY##*MiB}" ]; then
+    echo " Docker 'Total Memory' is measured in MiB, this is too low to run prepare polylines, please increase. See 'docker info' for full configuration."
+    exit 1
+  fi
+
+  if [ ${DOCKER_TOTAL_MEMORY/GiB/} \< 7.6 ]; then 
+    echo "Docker total memory is less than 4GB, prepare polylines will fail";
+    exit 1
+  fi;
+}
+
 # per-source prepares
-function prepare_polylines(){ compose_run -T 'polylines' bash ./docker_extract.sh; }
+function prepare_polylines(){ check_docker_memory; compose_run -T 'polylines' bash ./docker_extract.sh; }
 function prepare_interpolation(){ compose_run -T 'interpolation' bash ./docker_build.sh; }
 function prepare_placeholder(){
   compose_run -T 'placeholder' ./cmd/extract.sh;


### PR DESCRIPTION
My docker got reset to default config for some reason, which on mac is a memory limit of 2GB,
which means that polylines was being Killed by the linux kernel before
it could even start.

I think a larger fix might be to make sure that compose_run
appropriately gets the status output of the commands it runs and that
the scripts exit early if need by