### PR TITLE
Clarify that `ln` command may require sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ set -x
 git clone https://github.com/pelias/docker.git && cd docker
 
 # install pelias script
-ln -s "$(pwd)/pelias" /usr/local/bin/pelias
+# this is the _only_ setup command that should require `sudo`
+sudo ln -s "$(pwd)/pelias" /usr/local/bin/pelias
 
 # cd into the project directory
 cd projects/portland-metro


### PR DESCRIPTION
While other `pelias` commands should not be run with `sudo`, `sudo` will generally be required to create a symbolic link in `/usr/local/bin/` as described in our quickstart script.

This change adds `sudo` to that command and clarifies that it's the only part of the quickstart script that should use `sudo`.

Connects https://github.com/pelias/docker/issues/214