### PR TITLE
remove DOCKER_USER lines from project .env files

### DIFF
--- a/projects/norway/.env
+++ b/projects/norway/.env
@@ -1,3 +1,2 @@
 COMPOSE_PROJECT_NAME=pelias
-DOCKER_USER=1000
 DATA_DIR=/tmp/pelias/norway

--- a/projects/portland-metro/.env
+++ b/projects/portland-metro/.env
@@ -1,3 +1,2 @@
 COMPOSE_PROJECT_NAME=pelias
 DATA_DIR=/tmp/pelias/portland-metro
-DOCKER_USER=1000


### PR DESCRIPTION
a couple of `DOCKER_USER` lines have crept in to the .env files since merging https://github.com/pelias/docker/pull/220