### PR TITLE
Increase Elasticsearch `max_clause_count`

### DIFF
--- a/images/elasticsearch/7.5.1/elasticsearch.yml
+++ b/images/elasticsearch/7.5.1/elasticsearch.yml
@@ -6,3 +6,4 @@ node.data: true
 thread_pool:
   write:
     queue_size: 1000
+indices.query.bool.max_clause_count: 4000


### PR DESCRIPTION
Complex configurations with many synonyms can run into problems with
Elasticsearch throwing an error about exceeding the `max_clause_count`.

Internally, Elasticsearch takes queries that may be quite short and
rewrites them into potentially many Lucene clauses. The Elasticsearch
default
(https://www.elastic.co/guide/en/elasticsearch/reference/current/search-settings.html)
is to allow up to 1024 clauses.

While the Elasticsearch docs recommend against increasing this setting,
doing so allows us to handle more complex synonym configurations, and is
worth exploring.

Connects https://github.com/OpenTransitTools/trimet-mod-pelias/issues/33