### PR TITLE
Security

### DIFF
--- a/projects/south-africa/docker-compose.yml
+++ b/projects/south-africa/docker-compose.yml
@@ -113,7 +113,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "9200", "9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:


### PR DESCRIPTION
By default the docker-compose.yml pierces the firewall opening 9200 to the outside world. There is no valid reason to do this and allowing it can lead to various breaches including adding and removing data which can escalate up the chain.

:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
<!-- good place to use the magic github words that connect issues with PRs, like 
  - Fixes pelias/pelias#0000
  - Closes pelias/pelias#0000
  - Connected to pelias/pelias#0000
you can also just use good ol' words to explain what this does -->

---
#### Here's what actually got changed :clap:
<!-- try listing some of the things in a nifty checklist
- [x] :cat:
- [ ] :dog:
- [x] :rabbit:
-->

---
#### Here's how others can test the changes :eyes:
<!-- this could be queries or just mentioning that you've written unit/end-to-end tests as part of this awesome work... -->
<!-- did we mention, test are amazing! :rainbow: -->
