### PR TITLE
Restricted pelias+deps port exposure to localhost

### DIFF
--- a/projects/australia/docker-compose.yml
+++ b/projects/australia/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:4400:4400" ]
+    ports: [ "0.0.0.0:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "127.0.0.1:4100:4100" ]
+    ports: [ "0.0.0.0:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -103,7 +103,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "127.0.0.1:4300:4300" ]
+    ports: [ "0.0.0.0:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -113,7 +113,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "127.0.0.1:4200:4200" ]
+    ports: [ "0.0.0.0:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -122,7 +122,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
+    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/australia/docker-compose.yml
+++ b/projects/australia/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "0.0.0.0:4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "0.0.0.0:4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -103,7 +103,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "0.0.0.0:4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -113,7 +113,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "0.0.0.0:4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -122,7 +122,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/australia/docker-compose.yml
+++ b/projects/australia/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:

--- a/projects/australia/docker-compose.yml
+++ b/projects/australia/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -103,7 +103,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -113,7 +113,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -122,7 +122,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/austria/docker-compose.yml
+++ b/projects/austria/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "0.0.0.0:4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "0.0.0.0:4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -77,7 +77,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "0.0.0.0:4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "0.0.0.0:4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/austria/docker-compose.yml
+++ b/projects/austria/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:

--- a/projects/austria/docker-compose.yml
+++ b/projects/austria/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:4400:4400" ]
+    ports: [ "0.0.0.0:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "127.0.0.1:4100:4100" ]
+    ports: [ "0.0.0.0:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -77,7 +77,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "127.0.0.1:4300:4300" ]
+    ports: [ "0.0.0.0:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "127.0.0.1:4200:4200" ]
+    ports: [ "0.0.0.0:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
+    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/austria/docker-compose.yml
+++ b/projects/austria/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -77,7 +77,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/belgium/docker-compose.yml
+++ b/projects/belgium/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "0.0.0.0:4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "0.0.0.0:4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -77,7 +77,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "0.0.0.0:4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "0.0.0.0:4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/belgium/docker-compose.yml
+++ b/projects/belgium/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:

--- a/projects/belgium/docker-compose.yml
+++ b/projects/belgium/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:4400:4400" ]
+    ports: [ "0.0.0.0:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "127.0.0.1:4100:4100" ]
+    ports: [ "0.0.0.0:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -77,7 +77,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "127.0.0.1:4300:4300" ]
+    ports: [ "0.0.0.0:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "127.0.0.1:4200:4200" ]
+    ports: [ "0.0.0.0:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
+    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/belgium/docker-compose.yml
+++ b/projects/belgium/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -77,7 +77,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/brazil/docker-compose.yml
+++ b/projects/brazil/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "0.0.0.0:4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "0.0.0.0:4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "0.0.0.0:4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -97,7 +97,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "0.0.0.0:4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -106,7 +106,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/brazil/docker-compose.yml
+++ b/projects/brazil/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:4400:4400" ]
+    ports: [ "0.0.0.0:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "127.0.0.1:4100:4100" ]
+    ports: [ "0.0.0.0:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "127.0.0.1:4300:4300" ]
+    ports: [ "0.0.0.0:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -97,7 +97,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "127.0.0.1:4200:4200" ]
+    ports: [ "0.0.0.0:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -106,7 +106,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
+    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/brazil/docker-compose.yml
+++ b/projects/brazil/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -97,7 +97,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -106,7 +106,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/brazil/docker-compose.yml
+++ b/projects/brazil/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:

--- a/projects/france/docker-compose.yml
+++ b/projects/france/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "0.0.0.0:4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "0.0.0.0:4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -77,7 +77,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "0.0.0.0:4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "0.0.0.0:4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/france/docker-compose.yml
+++ b/projects/france/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:

--- a/projects/france/docker-compose.yml
+++ b/projects/france/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:4400:4400" ]
+    ports: [ "0.0.0.0:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "127.0.0.1:4100:4100" ]
+    ports: [ "0.0.0.0:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -77,7 +77,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "127.0.0.1:4300:4300" ]
+    ports: [ "0.0.0.0:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "127.0.0.1:4200:4200" ]
+    ports: [ "0.0.0.0:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
+    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/france/docker-compose.yml
+++ b/projects/france/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -77,7 +77,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/germany/docker-compose.yml
+++ b/projects/germany/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "0.0.0.0:4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "0.0.0.0:4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -77,7 +77,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "0.0.0.0:4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "0.0.0.0:4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/germany/docker-compose.yml
+++ b/projects/germany/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:

--- a/projects/germany/docker-compose.yml
+++ b/projects/germany/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:4400:4400" ]
+    ports: [ "0.0.0.0:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "127.0.0.1:4100:4100" ]
+    ports: [ "0.0.0.0:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -77,7 +77,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "127.0.0.1:4300:4300" ]
+    ports: [ "0.0.0.0:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "127.0.0.1:4200:4200" ]
+    ports: [ "0.0.0.0:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
+    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/germany/docker-compose.yml
+++ b/projects/germany/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -77,7 +77,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/jamaica/docker-compose.yml
+++ b/projects/jamaica/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "0.0.0.0:4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "0.0.0.0:4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "0.0.0.0:4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -97,7 +97,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "0.0.0.0:4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -106,7 +106,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/jamaica/docker-compose.yml
+++ b/projects/jamaica/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:4400:4400" ]
+    ports: [ "0.0.0.0:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "127.0.0.1:4100:4100" ]
+    ports: [ "0.0.0.0:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "127.0.0.1:4300:4300" ]
+    ports: [ "0.0.0.0:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -97,7 +97,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "127.0.0.1:4200:4200" ]
+    ports: [ "0.0.0.0:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -106,7 +106,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
+    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/jamaica/docker-compose.yml
+++ b/projects/jamaica/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -97,7 +97,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -106,7 +106,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/jamaica/docker-compose.yml
+++ b/projects/jamaica/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:

--- a/projects/los-angeles-metro/docker-compose.yml
+++ b/projects/los-angeles-metro/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:4400:4400" ]
+    ports: [ "0.0.0.0:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -23,7 +23,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -32,7 +32,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "127.0.0.1:4100:4100" ]
+    ports: [ "0.0.0.0:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -86,7 +86,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "127.0.0.1:4300:4300" ]
+    ports: [ "0.0.0.0:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "127.0.0.1:4200:4200" ]
+    ports: [ "0.0.0.0:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -105,7 +105,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
+    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/los-angeles-metro/docker-compose.yml
+++ b/projects/los-angeles-metro/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -23,7 +23,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "0.0.0.0:4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -32,7 +32,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "0.0.0.0:4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -86,7 +86,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "0.0.0.0:4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "0.0.0.0:4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -105,7 +105,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/los-angeles-metro/docker-compose.yml
+++ b/projects/los-angeles-metro/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:

--- a/projects/los-angeles-metro/docker-compose.yml
+++ b/projects/los-angeles-metro/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -23,7 +23,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -32,7 +32,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -86,7 +86,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -105,7 +105,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/netherlands/docker-compose.yml
+++ b/projects/netherlands/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "0.0.0.0:4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "0.0.0.0:4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -77,7 +77,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "0.0.0.0:4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "0.0.0.0:4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/netherlands/docker-compose.yml
+++ b/projects/netherlands/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:

--- a/projects/netherlands/docker-compose.yml
+++ b/projects/netherlands/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:4400:4400" ]
+    ports: [ "0.0.0.0:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "127.0.0.1:4100:4100" ]
+    ports: [ "0.0.0.0:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -77,7 +77,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "127.0.0.1:4300:4300" ]
+    ports: [ "0.0.0.0:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "127.0.0.1:4200:4200" ]
+    ports: [ "0.0.0.0:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
+    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/netherlands/docker-compose.yml
+++ b/projects/netherlands/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -77,7 +77,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/new-york-city/docker-compose.yml
+++ b/projects/new-york-city/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "0.0.0.0:4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "0.0.0.0:4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -95,7 +95,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "0.0.0.0:4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -105,7 +105,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "0.0.0.0:4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -114,7 +114,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/new-york-city/docker-compose.yml
+++ b/projects/new-york-city/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -95,7 +95,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -105,7 +105,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -114,7 +114,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/new-york-city/docker-compose.yml
+++ b/projects/new-york-city/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:

--- a/projects/new-york-city/docker-compose.yml
+++ b/projects/new-york-city/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:4400:4400" ]
+    ports: [ "0.0.0.0:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "127.0.0.1:4100:4100" ]
+    ports: [ "0.0.0.0:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -95,7 +95,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "127.0.0.1:4300:4300" ]
+    ports: [ "0.0.0.0:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -105,7 +105,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "127.0.0.1:4200:4200" ]
+    ports: [ "0.0.0.0:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -114,7 +114,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
+    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/north-america/docker-compose.yml
+++ b/projects/north-america/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -95,7 +95,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -105,7 +105,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -115,7 +115,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "ES_JAVA_OPTS=-Xmx8g" ]
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/north-america/docker-compose.yml
+++ b/projects/north-america/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:

--- a/projects/north-america/docker-compose.yml
+++ b/projects/north-america/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "0.0.0.0:4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "0.0.0.0:4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -95,7 +95,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "0.0.0.0:4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -105,7 +105,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "0.0.0.0:4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -115,7 +115,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "ES_JAVA_OPTS=-Xmx8g" ]
-    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/north-america/docker-compose.yml
+++ b/projects/north-america/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:4400:4400" ]
+    ports: [ "0.0.0.0:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "127.0.0.1:4100:4100" ]
+    ports: [ "0.0.0.0:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -95,7 +95,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "127.0.0.1:4300:4300" ]
+    ports: [ "0.0.0.0:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -105,7 +105,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "127.0.0.1:4200:4200" ]
+    ports: [ "0.0.0.0:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -115,7 +115,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "ES_JAVA_OPTS=-Xmx8g" ]
-    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
+    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/norway/docker-compose.yml
+++ b/projects/norway/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "0.0.0.0:4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "0.0.0.0:4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -77,7 +77,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "0.0.0.0:4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "0.0.0.0:4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/norway/docker-compose.yml
+++ b/projects/norway/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:

--- a/projects/norway/docker-compose.yml
+++ b/projects/norway/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:4400:4400" ]
+    ports: [ "0.0.0.0:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "127.0.0.1:4100:4100" ]
+    ports: [ "0.0.0.0:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -77,7 +77,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "127.0.0.1:4300:4300" ]
+    ports: [ "0.0.0.0:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "127.0.0.1:4200:4200" ]
+    ports: [ "0.0.0.0:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
+    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/norway/docker-compose.yml
+++ b/projects/norway/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -77,7 +77,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/planet/docker-compose.yml
+++ b/projects/planet/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -95,7 +95,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -105,7 +105,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -115,7 +115,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "ES_JAVA_OPTS=-Xmx8g" ]
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/planet/docker-compose.yml
+++ b/projects/planet/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:

--- a/projects/planet/docker-compose.yml
+++ b/projects/planet/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "0.0.0.0:4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "0.0.0.0:4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -95,7 +95,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "0.0.0.0:4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -105,7 +105,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "0.0.0.0:4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -115,7 +115,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "ES_JAVA_OPTS=-Xmx8g" ]
-    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/planet/docker-compose.yml
+++ b/projects/planet/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:4400:4400" ]
+    ports: [ "0.0.0.0:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "127.0.0.1:4100:4100" ]
+    ports: [ "0.0.0.0:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -95,7 +95,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "127.0.0.1:4300:4300" ]
+    ports: [ "0.0.0.0:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -105,7 +105,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "127.0.0.1:4200:4200" ]
+    ports: [ "0.0.0.0:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -115,7 +115,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "ES_JAVA_OPTS=-Xmx8g" ]
-    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
+    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/poland/docker-compose.yml
+++ b/projects/poland/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -84,7 +84,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -94,7 +94,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -103,7 +103,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/poland/docker-compose.yml
+++ b/projects/poland/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "0.0.0.0:4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "0.0.0.0:4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -84,7 +84,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "0.0.0.0:4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -94,7 +94,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "0.0.0.0:4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -103,7 +103,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/poland/docker-compose.yml
+++ b/projects/poland/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:

--- a/projects/poland/docker-compose.yml
+++ b/projects/poland/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:4400:4400" ]
+    ports: [ "0.0.0.0:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "127.0.0.1:4100:4100" ]
+    ports: [ "0.0.0.0:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -84,7 +84,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "127.0.0.1:4300:4300" ]
+    ports: [ "0.0.0.0:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -94,7 +94,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "127.0.0.1:4200:4200" ]
+    ports: [ "0.0.0.0:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -103,7 +103,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
+    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro"
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "0.0.0.0:4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "0.0.0.0:4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "0.0.0.0:4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -97,7 +97,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "0.0.0.0:4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -106,7 +106,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:4400:4400" ]
+    ports: [ "0.0.0.0:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "127.0.0.1:4100:4100" ]
+    ports: [ "0.0.0.0:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "127.0.0.1:4300:4300" ]
+    ports: [ "0.0.0.0:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -97,7 +97,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "127.0.0.1:4200:4200" ]
+    ports: [ "0.0.0.0:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -106,7 +106,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
+    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -97,7 +97,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -106,7 +106,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:

--- a/projects/san-jose-metro/docker-compose.yml
+++ b/projects/san-jose-metro/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:4400:4400" ]
+    ports: [ "0.0.0.0:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -23,7 +23,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -32,7 +32,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "127.0.0.1:4100:4100" ]
+    ports: [ "0.0.0.0:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -86,7 +86,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "127.0.0.1:4300:4300" ]
+    ports: [ "0.0.0.0:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "127.0.0.1:4200:4200" ]
+    ports: [ "0.0.0.0:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -105,7 +105,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
+    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/san-jose-metro/docker-compose.yml
+++ b/projects/san-jose-metro/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -23,7 +23,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "0.0.0.0:4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -32,7 +32,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "0.0.0.0:4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -86,7 +86,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "0.0.0.0:4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "0.0.0.0:4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -105,7 +105,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/san-jose-metro/docker-compose.yml
+++ b/projects/san-jose-metro/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:

--- a/projects/san-jose-metro/docker-compose.yml
+++ b/projects/san-jose-metro/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -23,7 +23,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -32,7 +32,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -86,7 +86,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -96,7 +96,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -105,7 +105,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/singapore/docker-compose.yml
+++ b/projects/singapore/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -82,7 +82,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -92,7 +92,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -101,7 +101,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/singapore/docker-compose.yml
+++ b/projects/singapore/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:4400:4400" ]
+    ports: [ "0.0.0.0:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "127.0.0.1:4100:4100" ]
+    ports: [ "0.0.0.0:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -82,7 +82,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "127.0.0.1:4300:4300" ]
+    ports: [ "0.0.0.0:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -92,7 +92,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "127.0.0.1:4200:4200" ]
+    ports: [ "0.0.0.0:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -101,7 +101,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
+    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/singapore/docker-compose.yml
+++ b/projects/singapore/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:

--- a/projects/singapore/docker-compose.yml
+++ b/projects/singapore/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "0.0.0.0:4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "0.0.0.0:4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -82,7 +82,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "0.0.0.0:4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -92,7 +92,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "0.0.0.0:4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -101,7 +101,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/south-africa/docker-compose.yml
+++ b/projects/south-africa/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -23,7 +23,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "0.0.0.0:4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -32,7 +32,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "0.0.0.0:4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "0.0.0.0:4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -97,7 +97,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "0.0.0.0:4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -105,7 +105,7 @@ services:
     image: nginx
     container_name: pelias_preview
     restart: always
-    ports: [ "0.0.0.0:3000:80" ]
+    ports: [ "127.0.0.1:3000:80" ]
     volumes:
       - "../../common/preview:/usr/share/nginx/html"
   elasticsearch:
@@ -113,7 +113,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/south-africa/docker-compose.yml
+++ b/projects/south-africa/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:4400:4400" ]
+    ports: [ "0.0.0.0:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -23,7 +23,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -32,7 +32,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "127.0.0.1:4100:4100" ]
+    ports: [ "0.0.0.0:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "127.0.0.1:4300:4300" ]
+    ports: [ "0.0.0.0:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -97,7 +97,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "127.0.0.1:4200:4200" ]
+    ports: [ "0.0.0.0:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -105,7 +105,7 @@ services:
     image: nginx
     container_name: pelias_preview
     restart: always
-    ports: [ "127.0.0.1:3000:80" ]
+    ports: [ "0.0.0.0:3000:80" ]
     volumes:
       - "../../common/preview:/usr/share/nginx/html"
   elasticsearch:
@@ -113,7 +113,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
+    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/south-africa/docker-compose.yml
+++ b/projects/south-africa/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:

--- a/projects/south-africa/docker-compose.yml
+++ b/projects/south-africa/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -23,7 +23,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -32,7 +32,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -97,7 +97,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -105,7 +105,7 @@ services:
     image: nginx
     container_name: pelias_preview
     restart: always
-    ports: [ "3000:80" ]
+    ports: [ "127.0.0.1:3000:80" ]
     volumes:
       - "../../common/preview:/usr/share/nginx/html"
   elasticsearch:
@@ -113,7 +113,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/south-america/docker-compose.yml
+++ b/projects/south-america/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "0.0.0.0:4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "0.0.0.0:4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "0.0.0.0:4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -97,7 +97,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "0.0.0.0:4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -106,7 +106,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/south-america/docker-compose.yml
+++ b/projects/south-america/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:4400:4400" ]
+    ports: [ "0.0.0.0:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "127.0.0.1:4100:4100" ]
+    ports: [ "0.0.0.0:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "127.0.0.1:4300:4300" ]
+    ports: [ "0.0.0.0:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -97,7 +97,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "127.0.0.1:4200:4200" ]
+    ports: [ "0.0.0.0:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -106,7 +106,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
+    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/south-america/docker-compose.yml
+++ b/projects/south-america/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -30,7 +30,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -87,7 +87,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -97,7 +97,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -106,7 +106,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/south-america/docker-compose.yml
+++ b/projects/south-america/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:

--- a/projects/texas/docker-compose.yml
+++ b/projects/texas/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -23,7 +23,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -32,7 +32,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -89,7 +89,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -99,7 +99,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -108,7 +108,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "9200:9200", "9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/texas/docker-compose.yml
+++ b/projects/texas/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:4400:4400" ]
+    ports: [ "127.0.0.1:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -23,7 +23,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "0.0.0.0:4000:4000" ]
+    ports: [ "127.0.0.1:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -32,7 +32,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "0.0.0.0:4100:4100" ]
+    ports: [ "127.0.0.1:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -89,7 +89,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "0.0.0.0:4300:4300" ]
+    ports: [ "127.0.0.1:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -99,7 +99,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "0.0.0.0:4200:4200" ]
+    ports: [ "127.0.0.1:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -108,7 +108,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
+    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:

--- a/projects/texas/docker-compose.yml
+++ b/projects/texas/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:

--- a/projects/texas/docker-compose.yml
+++ b/projects/texas/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pelias_libpostal
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:4400:4400" ]
+    ports: [ "0.0.0.0:4400:4400" ]
   schema:
     image: pelias/schema:master
     container_name: pelias_schema
@@ -23,7 +23,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4000" ]
-    ports: [ "127.0.0.1:4000:4000" ]
+    ports: [ "0.0.0.0:4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
   placeholder:
@@ -32,7 +32,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4100" ]
-    ports: [ "127.0.0.1:4100:4100" ]
+    ports: [ "0.0.0.0:4100:4100" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -89,7 +89,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4300" ]
-    ports: [ "127.0.0.1:4300:4300" ]
+    ports: [ "0.0.0.0:4300:4300" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -99,7 +99,7 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     environment: [ "PORT=4200" ]
-    ports: [ "127.0.0.1:4200:4200" ]
+    ports: [ "0.0.0.0:4200:4200" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
@@ -108,7 +108,7 @@ services:
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always
-    ports: [ "127.0.0.1:9200:9200", "127.0.0.1:9300:9300" ]
+    ports: [ "0.0.0.0:9200:9200", "0.0.0.0:9300:9300" ]
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

This change should improve the default security  level for the docker containers in pelias-docker.

---
#### Here's the reason for this change :rocket:

This is a change based on feedback from pelias/docker#254

---
#### Here's what actually got changed :clap:
Very little got changed, just port bindings in the docker compose files (for all api's - including pelias).

---
#### Here's how others can test the changes :eyes:

I have already done some testing, this behaved as expected. (I completed a full Australia build and deploy, and it correctly deployed, enabled access to apis on the machine itself, but did not allow network access to them). The API's that were to be exposed had to be explicitly exposed via a mechanism that re-routed the internal requests to external access (reverse proxy in my case).

A standard run-through install and use of the docker files, should prove this works.