### PR TITLE
Upgrade Elasticearch to version 7.16.1

### DIFF
--- a/projects/australia/docker-compose.yml
+++ b/projects/australia/docker-compose.yml
@@ -118,7 +118,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.5.1
+    image: pelias/elasticsearch:7.16.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/austria/docker-compose.yml
+++ b/projects/austria/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.5.1
+    image: pelias/elasticsearch:7.16.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/belgium/docker-compose.yml
+++ b/projects/belgium/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.5.1
+    image: pelias/elasticsearch:7.16.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/brazil/docker-compose.yml
+++ b/projects/brazil/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.5.1
+    image: pelias/elasticsearch:7.16.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/france/docker-compose.yml
+++ b/projects/france/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.5.1
+    image: pelias/elasticsearch:7.16.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/germany/docker-compose.yml
+++ b/projects/germany/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.5.1
+    image: pelias/elasticsearch:7.16.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/jamaica/docker-compose.yml
+++ b/projects/jamaica/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.5.1
+    image: pelias/elasticsearch:7.16.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/los-angeles-metro/docker-compose.yml
+++ b/projects/los-angeles-metro/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.5.1
+    image: pelias/elasticsearch:7.16.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/netherlands/docker-compose.yml
+++ b/projects/netherlands/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.5.1
+    image: pelias/elasticsearch:7.16.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/new-york-city/docker-compose.yml
+++ b/projects/new-york-city/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.5.1
+    image: pelias/elasticsearch:7.16.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/north-america/docker-compose.yml
+++ b/projects/north-america/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.5.1
+    image: pelias/elasticsearch:7.16.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/norway/docker-compose.yml
+++ b/projects/norway/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.5.1
+    image: pelias/elasticsearch:7.16.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/planet/docker-compose.yml
+++ b/projects/planet/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.5.1
+    image: pelias/elasticsearch:7.16.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/poland/docker-compose.yml
+++ b/projects/poland/docker-compose.yml
@@ -99,7 +99,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.5.1
+    image: pelias/elasticsearch:7.16.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.5.1
+    image: pelias/elasticsearch:7.16.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/san-jose-metro/docker-compose.yml
+++ b/projects/san-jose-metro/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.5.1
+    image: pelias/elasticsearch:7.16.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/singapore/docker-compose.yml
+++ b/projects/singapore/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.5.1
+    image: pelias/elasticsearch:7.16.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/south-africa/docker-compose.yml
+++ b/projects/south-africa/docker-compose.yml
@@ -109,7 +109,7 @@ services:
     volumes:
       - "../../common/preview:/usr/share/nginx/html"
   elasticsearch:
-    image: pelias/elasticsearch:7.5.1
+    image: pelias/elasticsearch:7.16.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/south-america/docker-compose.yml
+++ b/projects/south-america/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.5.1
+    image: pelias/elasticsearch:7.16.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/texas/docker-compose.yml
+++ b/projects/texas/docker-compose.yml
@@ -104,7 +104,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.5.1
+    image: pelias/elasticsearch:7.16.1
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always


### PR DESCRIPTION
Upgrade the default Elasticsearch image to use version 7.16.1.

This version contains fixes for the log4j 'log4shell' security vulnerability.

Closes https://github.com/pelias/docker/issues/273
Connects https://github.com/pelias/pelias/issues/921