### PR TITLE
projects: portland-metro CSV URL fix

### DIFF
--- a/projects/portland-metro/pelias.json
+++ b/projects/portland-metro/pelias.json
@@ -95,7 +95,7 @@
       "feeds": [
         {
           "layerId": "bikeshare",
-          "url": "http://biketownpdx.socialbicycles.com/opendata/station_information.json",
+          "url": "https://gbfs.biketownpdx.com/gbfs/en/station_information.json",
           "filename": "BIKETOWN-hubs.json",
           "agencyId": "BIKETOWN",
           "agencyName": "BIKETOWN",


### PR DESCRIPTION
the file `http://biketownpdx.socialbicycles.com/opendata/station_information.json` is now hosted at `https://gbfs.biketownpdx.com/gbfs/en/station_information.json`