### PR TITLE
Support for docker-compose as part of docker

### DIFF
--- a/cmd/docker.sh
+++ b/cmd/docker.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -e;
 
+# We default to use docker-compose if its installed on the system. If not we will use docker compose
+if ! command -v docker-compose &> /dev/null
+then
+    DOCKER_COMPOSE_COMMAND="docker compose"
+    exit
+else 
+    DOCKER_COMPOSE_COMMAND="docker-compose"
+fi
+
 function net_init(){
   docker network create ${COMPOSE_PROJECT_NAME}_default &>/dev/null || true
 }
@@ -17,18 +26,18 @@ register 'compose' 'ps' 'list containers' compose_ps
 function compose_top(){ compose_exec top $@; }
 register 'compose' 'top' 'display the running processes of a container' compose_top
 
-function compose_exec(){ docker-compose $@; }
-register 'compose' 'exec' 'execute an arbitrary docker-compose command' compose_exec
+function compose_exec(){ ${DOCKER_COMPOSE_COMMAND} $@; }
+register 'compose' 'exec' 'execute an arbitrary ${DOCKER_COMPOSE_COMMAND} command' compose_exec
 
-function compose_run(){ net_init; docker-compose run --rm $@; }
-register 'compose' 'run' 'execute a docker-compose run command' compose_run
+function compose_run(){ net_init; ${DOCKER_COMPOSE_COMMAND} run --rm $@; }
+register 'compose' 'run' 'execute a ${DOCKER_COMPOSE_COMMAND} run command' compose_run
 
-function compose_up(){ docker-compose up -d $@; }
-register 'compose' 'up' 'start one or more docker-compose service(s)' compose_up
+function compose_up(){ ${DOCKER_COMPOSE_COMMAND} up -d $@; }
+register 'compose' 'up' 'start one or more ${DOCKER_COMPOSE_COMMAND} service(s)' compose_up
 
-function compose_kill(){ docker-compose kill $@; }
-register 'compose' 'kill' 'kill one or more docker-compose service(s)' compose_kill
+function compose_kill(){ ${DOCKER_COMPOSE_COMMAND} kill $@; }
+register 'compose' 'kill' 'kill one or more ${DOCKER_COMPOSE_COMMAND} service(s)' compose_kill
 
-function compose_down(){ docker-compose down; }
-register 'compose' 'down' 'stop all docker-compose service(s)' compose_down
+function compose_down(){ ${DOCKER_COMPOSE_COMMAND} down; }
+register 'compose' 'down' 'stop all ${DOCKER_COMPOSE_COMMAND} service(s)' compose_down
 


### PR DESCRIPTION
newer versions of docker comes with docker-compose as part of it. therefore we should use this command to call.

We do not take into account WHICH version is running etc. only whether command exists or not

#### Here's how others can test the changes :eyes:
<!-- this could be queries or just mentioning that you've written unit/end-to-end tests as part of this awesome work... -->
<!-- did we mention, test are amazing! :rainbow: -->
