### PR TITLE
portland-metro: fix broken data URLS

### DIFF
--- a/projects/portland-metro/pelias.json
+++ b/projects/portland-metro/pelias.json
@@ -57,7 +57,7 @@
     },
     "openstreetmap": {
       "download": [
-        { "sourceURL": "https://s3.amazonaws.com/metro-extracts.nextzen.org/portland_oregon.osm.pbf" }
+        { "sourceURL": "https://data.geocode.earth/archive/portland-metro/2022-06-20/portland_oregon.osm.pbf" }
       ],
       "leveldbpath": "/tmp",
       "datapath": "/data/openstreetmap",
@@ -111,7 +111,7 @@
         },
         {
           "layerId": "stops",
-          "url": "http://www.c-tran.com/images/Google/GoogleTransitUpload.zip",
+          "url": "https://data.geocode.earth/archive/portland-metro/2022-06-20/C-TRAN.zip",
           "filename": "C-TRAN-stops.txt",
           "agencyId": "C-TRAN",
           "agencyName": "C-TRAN",


### PR DESCRIPTION
as mentioned in the linked issues, two of the data URLs from the `portland-metro` project are broken.

I have uploaded copies from my local machine circa `2022-06-20` until we can find new URLs which point to up-to-date data.

linked: https://github.com/pelias/docker/issues/308
linked: https://github.com/pelias/docker/issues/293
closes https://github.com/pelias/docker/issues/293