### PR TITLE
fix: grep pattern fixed to remove line comments

### DIFF
--- a/lib/env.sh
+++ b/lib/env.sh
@@ -58,7 +58,7 @@ function env_load_stream(){
 
 # load DATA_DIR and other vars from docker-compose .env file
 # note: strips comments and empty lines
-[ -f .env ] && env_load_stream < <(grep -v '^$\|^\s*$\#' .env)
+[ -f .env ] && env_load_stream < <(grep -v '^$\|^\s*$#' .env)
 
 # use the default compose file unless one was specified
 # if [ -z "${COMPOSE_FILE}" ]; then

--- a/lib/env.sh
+++ b/lib/env.sh
@@ -58,7 +58,7 @@ function env_load_stream(){
 
 # load DATA_DIR and other vars from docker-compose .env file
 # note: strips comments and empty lines
-[ -f .env ] && env_load_stream < <(grep -v '^$\|^\s*$#' .env)
+[ -f .env ] && env_load_stream < <(grep -v '^$\|^\s*#' .env)
 
 # use the default compose file unless one was specified
 # if [ -z "${COMPOSE_FILE}" ]; then


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:

1) Running `pelias` yields the error `grep: warning: stray \ before #`.
2) Line comments were not removed by grep pattern.

---
#### Here's what actually got changed :clap:
1) This can be fixed by not escaping `#` in the grep pattern.
2) The grep pattern: There was a end-of-line anchor `$` after a pattern for white-spaces `\s*` before the line-comment character `#`. This was changed to `^\s*#` which remove lines starting with 0 or more whitespace characters followed by `#`.

---
#### Here's how others can test the changes :eyes:
Run the `pelias` command and check if loading .env variables does still work as expected/is now fixed. Especially if line comments (with and without whitespace before `#`) get removed.
