### PR TITLE
North America Project README.md link fix

### DIFF
--- a/projects/north-america/README.md
+++ b/projects/north-america/README.md
@@ -38,4 +38,4 @@ pelias test run
 
 You can now make queries against your new Pelias build:
 
-[http://localhost:4000/v1/search?text=empire state building](localhost:4000/v1/search?text=empire%20state%20building)
+[http://localhost:4000/v1/search?text=empire state building](http://localhost:4000/v1/search?text=empire%20state%20building)

--- a/projects/north-america/README.md
+++ b/projects/north-america/README.md
@@ -38,4 +38,4 @@ pelias test run
 
 You can now make queries against your new Pelias build:
 
-[http://localhost:4000/v1/search?text=empire state building](http://localhost:4000/v1/search?text=empire state building)
+[http://localhost:4000/v1/search?text=empire state building](localhost:4000/v1/search?text=empire%20state%20building)


### PR DESCRIPTION
Properly encoded the reference query URL at the bottom of the README.md so that it renders and functions correctly.

Sorry for not squashing but I did this without a cli in the browser.