### PR TITLE
support modern docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ We think open data, open source, and open strategy win over proprietary solution
 
 # Pelias in Docker
 
-This repository contains a framework for downloading/preparing and building the [Pelias Geocoder](https://github.com/pelias/pelias) using Docker and [Docker Compose](https://github.com/docker/compose#docker-compose).
+This repository contains a framework for downloading/preparing and building the [Pelias Geocoder](https://github.com/pelias/pelias) using Docker and [Docker Compose](https://github.com/docker/compose#docker-compose-v2).
 
 ## Projects
 
@@ -36,7 +36,7 @@ Once you have successfully completed a small build you can use this as a base to
 
 ## Prerequisites
 
-You will need to have a [modern version of `docker`](https://docs.docker.com/engine/release-notes/) and a [modern version of `docker-compose`](https://github.com/docker/compose/blob/master/CHANGELOG.md) installed before continuing. If you are not using the latest version, please mention that in any bugs reports.
+You will need to have a [modern version of `docker`](https://docs.docker.com/engine/release-notes/) and a [modern version of `docker compose`](https://github.com/docker/compose/releases) installed before continuing. If you are not using the latest version, please mention that in any bugs reports.
 
 This project supports Linux and Mac OSX operatings systems. Windows is currently [not supported](https://github.com/pelias/docker/issues/124).
 
@@ -214,11 +214,11 @@ Usage: pelias [command] [action] [options]
   compose   logs                     display container logs
   compose   ps                       list containers
   compose   top                      display the running processes of a container
-  compose   exec                     execute an arbitrary docker-compose command
-  compose   run                      execute a docker-compose run command
-  compose   up                       start one or more docker-compose service(s)
-  compose   kill                     kill one or more docker-compose service(s)
-  compose   down                     stop all docker-compose service(s)
+  compose   exec                     execute an arbitrary docker compose command
+  compose   run                      execute a docker compose run command
+  compose   up                       start one or more docker compose service(s)
+  compose   kill                     kill one or more docker compose service(s)
+  compose   down                     stop all docker compose service(s)
   download  wof                      (re)download whosonfirst data
   download  oa                       (re)download openaddresses data
   download  osm                      (re)download openstreetmap data
@@ -251,20 +251,20 @@ Usage: pelias [command] [action] [options]
 
 ### Compose commands
 
-The compose commands are available as a shortcut to running `docker-compose` directly, they will also ensure that your environment is correctly configured.
+The compose commands are available as a shortcut to running `docker compose` directly, they will also ensure that your environment is correctly configured.
 
-See the docker-compose documentation for more info: https://docs.docker.com/compose/overview/
+See the docker compose documentation for more info: https://docs.docker.com/compose/overview/
 
 ```bash
 pelias compose pull                     update all docker images
 pelias compose logs                     display container logs
 pelias compose ps                       list containers
 pelias compose top                      display the running processes of a container
-pelias compose exec                     execute an arbitrary docker-compose command
-pelias compose run                      execute a docker-compose run command
-pelias compose up                       start one or more docker-compose service(s)
-pelias compose kill                     kill one or more docker-compose service(s)
-pelias compose down                     stop all docker-compose service(s)
+pelias compose exec                     execute an arbitrary docker compose command
+pelias compose run                      execute a docker compose run command
+pelias compose up                       start one or more docker compose service(s)
+pelias compose kill                     kill one or more docker compose service(s)
+pelias compose down                     stop all docker compose service(s)
 ```
 
 ### Download commands

--- a/cmd/docker.sh
+++ b/cmd/docker.sh
@@ -17,18 +17,22 @@ register 'compose' 'ps' 'list containers' compose_ps
 function compose_top(){ compose_exec top $@; }
 register 'compose' 'top' 'display the running processes of a container' compose_top
 
-function compose_exec(){ docker-compose $@; }
-register 'compose' 'exec' 'execute an arbitrary docker-compose command' compose_exec
+function compose_exec(){
+  # fall back to legacy `docker-compose` when modern `docker compose` invocation isn't available
+  local _compose_exec=$(docker compose > /dev/null 2>&1 && echo "docker compose" || echo "docker-compose")
+  $_compose_exec $@;
+}
+register 'compose' 'exec' 'execute an arbitrary `docker compose` command' compose_exec
 
-function compose_run(){ net_init; docker-compose run --rm $@; }
-register 'compose' 'run' 'execute a docker-compose run command' compose_run
+function compose_run(){ net_init; compose_exec run --rm $@; }
+register 'compose' 'run' 'execute a `docker compose` run command' compose_run
 
-function compose_up(){ docker-compose up -d $@; }
-register 'compose' 'up' 'start one or more docker-compose service(s)' compose_up
+function compose_up(){ compose_exec up -d $@; }
+register 'compose' 'up' 'start one or more `docker compose` service(s)' compose_up
 
-function compose_kill(){ docker-compose kill $@; }
-register 'compose' 'kill' 'kill one or more docker-compose service(s)' compose_kill
+function compose_kill(){ compose_exec kill $@; }
+register 'compose' 'kill' 'kill one or more `docker compose` service(s)' compose_kill
 
-function compose_down(){ docker-compose down; }
-register 'compose' 'down' 'stop all docker-compose service(s)' compose_down
+function compose_down(){ compose_exec down; }
+register 'compose' 'down' 'stop all `docker compose` service(s)' compose_down
 

--- a/cmd/docker.sh
+++ b/cmd/docker.sh
@@ -17,10 +17,15 @@ register 'compose' 'ps' 'list containers' compose_ps
 function compose_top(){ compose_exec top $@; }
 register 'compose' 'top' 'display the running processes of a container' compose_top
 
+# the 'docker compose' subcommand is now the recommended method of calling compose.
+# if not available, we fallback to the legacy 'docker-compose' command.
 function compose_exec(){
-  # fall back to legacy `docker-compose` when modern `docker compose` invocation isn't available
-  local _compose_exec=$(docker compose > /dev/null 2>&1 && echo "docker compose" || echo "docker-compose")
-  $_compose_exec $@;
+  NATIVE_COMPOSE_VERSION=$(docker compose version 2> /dev/null || true)
+  if [ -z "$NATIVE_COMPOSE_VERSION" ]; then
+    docker-compose $@;
+  else
+    docker compose $@;
+  fi
 }
 register 'compose' 'exec' 'execute an arbitrary `docker compose` command' compose_exec
 

--- a/lib/env.sh
+++ b/lib/env.sh
@@ -56,7 +56,7 @@ function env_load_stream(){
 # ensure locale is correctly set?
 # export LC_ALL=en_US.UTF-8
 
-# load DATA_DIR and other vars from docker-compose .env file
+# load DATA_DIR and other vars from docker compose .env file
 # note: strips comments and empty lines
 [ -f .env ] && env_load_stream < <(grep -v '^$\|^\s*$\#' .env)
 


### PR DESCRIPTION
#### Here's the reason for this change :rocket:

Fixes error like:

	line 20: docker-compose: command not found

From: https://docs.docker.com/compose/gettingstarted/

> Compose V1 no longer receives updates and will not be available in new releases of Docker Desktop after June 2023.

---

#### Here's what actually got changed :clap:

- update docker compose docs
- refreshed links related to docker compose
- - all the docker commands now delegate to compose_exec (previously only half did)
- `compose_exec` now first tries `docker compose` before falling back to docker-compose`

Alternatively we could just drop docker-compose (v1) support. I confess that I didn't fully test the fallback behavior anyway, and apparently it's no longer supported by docker.

---
#### Here's how others can test the changes :eyes:

Run through any of the example projects that utilize a variety of docker compose commands, e.g. portland-metro

closes https://github.com/pelias/docker/pull/303