### PR TITLE
This test is not failing (maybe it was previously?)

### DIFF
--- a/projects/portland-metro/test_cases/search_venue.json
+++ b/projects/portland-metro/test_cases/search_venue.json
@@ -5,7 +5,7 @@
   "tests": [
     {
       "id": 1,
-      "status": "fail",
+      "status": "pass",
       "notes": "portland international should come up for PDX",
       "in": {
         "text": "pdx"


### PR DESCRIPTION
Note its sibling test was marked as passing in [627ddaba21d0163036570ee0576cf45c9c1d5ce6](https://github.com/pelias/docker/commit/627ddaba21d0163036570ee0576cf45c9c1d5ce6#diff-820b87478307aee94111365f6b543b9ef578e59040e220566b1afe6be068ff07L29)

I imagine it's pretty challenging to keep all the integration tests up to date, given the churn/fragility of relying on externally edited datasets like openstreetmap and openaddreses.

My understanding, based on #204, is that we don't necessarily expect all the tests in this repository to be accurate, and some are aspirational, but we do want the "full planet" and portland-metro in particular to be accurate.

The "full planet" tests are presumably important for their completeness while portland-metro is presumably important because it serves as a quick-but-complete example.

## Testing

I ran the instructions in the [readme](https://github.com/pelias/docker/blob/master/projects/portland-metro/README.md) to import the portland-metro and run the test suite.

**before**
```
/v1/search venues
  ✔ improvement [1] "/v1/search?text=pdx"
  ✔ [2] "/v1/search?text=pdx airport"

Aggregate test results
Pass: 402
Improvements: 1
Expected Failures: 73
Placeholders: 0
Regressions: 0
Total tests: 476
Took 5174ms
Test success rate 100%

0 regressions detected. All good.
```

**after**
```
/v1/search venues
  ✔ [1] "/v1/search?text=pdx"
  ✔ [2] "/v1/search?text=pdx airport"

Aggregate test results
Pass: 403
Improvements: 0
Expected Failures: 73
Placeholders: 0
Regressions: 0
Total tests: 476
Took 5080ms
Test success rate 100%
```
