### PR TITLE
add pelias/elasticsearch:8.12.2-beta docker image

### DIFF
--- a/images/elasticsearch/8.12.2-beta/Dockerfile
+++ b/images/elasticsearch/8.12.2-beta/Dockerfile
@@ -1,0 +1,36 @@
+# see: https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
+
+# base image
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.12.2
+USER root
+
+# environmental settings
+ENV ES_JAVA_OPTS '-Xms512m -Xmx512m'
+ENV cluster.name 'pelias-dev'
+ENV discovery.type 'single-node'
+ENV bootstrap.memory_lock 'true'
+RUN echo 'vm.max_map_count=262144' >> /etc/sysctl.conf
+
+# configure plugins
+RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu
+RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install repository-s3 --batch
+
+# elasticsearch config
+ADD elasticsearch.yml /usr/share/elasticsearch/config/
+RUN chown elasticsearch:elasticsearch config/elasticsearch.yml
+
+## set permissions so any user can run elasticsearch
+# add read permissions to all files in dir
+RUN chmod go+r /usr/share/elasticsearch -R
+
+# add write permissions to config, log & data dirs
+RUN chmod go+w /usr/share/elasticsearch \
+  /usr/share/elasticsearch/config \
+  /usr/share/elasticsearch/logs \
+  /usr/share/elasticsearch/data
+
+# add execute permissions to bins
+RUN chmod go+x /usr/share/elasticsearch/bin/*
+
+# run as elasticsearch user
+USER elasticsearch

--- a/images/elasticsearch/8.12.2-beta/elasticsearch.yml
+++ b/images/elasticsearch/8.12.2-beta/elasticsearch.yml
@@ -1,0 +1,9 @@
+bootstrap.memory_lock: true
+network.host: 0.0.0.0
+http.port: 9200
+node.roles: [ master, data ]
+thread_pool:
+  write:
+    queue_size: 1000
+indices.query.bool.max_clause_count: 4000
+xpack.security.enabled: false


### PR DESCRIPTION
this PR adds a [pelias/elasticsearch:8.12.2-beta](https://hub.docker.com/layers/pelias/elasticsearch/8.12.2-beta/images/sha256-4cb6a026bbd3edc18878c0937e73f33f59b0a1ae02591e5c31aa2ebb41cfb384?context=explore) docker image for testing.

cc/ @michaelkirk 