### PR TITLE
update elasticsearch to v7.17.27

### DIFF
--- a/projects/australia/docker-compose.yml
+++ b/projects/australia/docker-compose.yml
@@ -118,7 +118,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/austria/docker-compose.yml
+++ b/projects/austria/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/belgium/docker-compose.yml
+++ b/projects/belgium/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/brazil/docker-compose.yml
+++ b/projects/brazil/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/denmark/docker-compose.yml
+++ b/projects/denmark/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/france/docker-compose.yml
+++ b/projects/france/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/germany/docker-compose.yml
+++ b/projects/germany/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/israel/docker-compose.yml
+++ b/projects/israel/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/italy/docker-compose.yml
+++ b/projects/italy/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/jamaica/docker-compose.yml
+++ b/projects/jamaica/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/las-vegas-metro/docker-compose.yml
+++ b/projects/las-vegas-metro/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/lithuania/docker-compose.yml
+++ b/projects/lithuania/docker-compose.yml
@@ -99,7 +99,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/los-angeles-metro/docker-compose.yml
+++ b/projects/los-angeles-metro/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/netherlands/docker-compose.yml
+++ b/projects/netherlands/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/new-york-city/docker-compose.yml
+++ b/projects/new-york-city/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/north-america/docker-compose.yml
+++ b/projects/north-america/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/norway/docker-compose.yml
+++ b/projects/norway/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/planet/docker-compose.yml
+++ b/projects/planet/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/poland/docker-compose.yml
+++ b/projects/poland/docker-compose.yml
@@ -99,7 +99,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/san-jose-metro/docker-compose.yml
+++ b/projects/san-jose-metro/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/singapore/docker-compose.yml
+++ b/projects/singapore/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/south-africa/docker-compose.yml
+++ b/projects/south-africa/docker-compose.yml
@@ -109,7 +109,7 @@ services:
     volumes:
       - "../../common/preview:/usr/share/nginx/html"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/south-america/docker-compose.yml
+++ b/projects/south-america/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always

--- a/projects/texas/docker-compose.yml
+++ b/projects/texas/docker-compose.yml
@@ -104,7 +104,7 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
   elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:7.17.27
     container_name: pelias_elasticsearch
     user: "${DOCKER_USER}"
     restart: always


### PR DESCRIPTION
Happy new year, `v7.17.27` was released 14 January 2025

https://hub.docker.com/layers/pelias/elasticsearch/7.17.27/images/sha256-42acb7033e92ae492a889d2d47a9e3dac7443e03c3287cc91465c7847a149a58

Oneliner:

```bash
grep -l '7\.16\.1' projects/**/docker-compose.yml \
  | xargs gsed -i 's/7\.16\.1/7\.17\.27/g'
```

Resolves https://github.com/pelias/docker/issues/366