### PR TITLE
CI: update Github Action runner Ubuntu versions to 22.04

### DIFF
--- a/.github/workflows/elasticsearch-image-builder.yml
+++ b/.github/workflows/elasticsearch-image-builder.yml
@@ -7,7 +7,7 @@
 # jobs:
 #   build:
 #     if: github.ref == 'refs/heads/master' && needs.unit-tests.result == 'success'
-#     runs-on: ubuntu-20.04
+#     runs-on: ubuntu-22.04
 #     strategy:
 #       matrix:
 #         elastic-version:


### PR DESCRIPTION
GitHub is deprecating Ubuntu 20 based runners [on April 1](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/), so we want to be off well before then.

Connects https://github.com/pelias/pelias/issues/951