### PR TITLE
fix(australia): remove duplicate `csv-importer` service from docker-compose.yml

### DIFF
--- a/projects/australia/docker-compose.yml
+++ b/projects/australia/docker-compose.yml
@@ -67,14 +67,6 @@ services:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
       - "./blacklist/:/data/blacklist"
-  csv-importer:
-    image: pelias/csv-importer:master
-    container_name: pelias_csv_importer
-    user: "${DOCKER_USER}"
-    volumes:
-      - "./pelias.json:/code/pelias.json"
-      - "${DATA_DIR}:/data"
-      - "./blacklist/:/data/blacklist"
   transit:
     image: pelias/transit:master
     container_name: pelias_transit


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
The `csv-importer` service is duplicated in the `projects/australia/docker-compose.yml` file, causing errors when running `pelias compose` commands.
<img width="543" alt="Screenshot 2025-02-25 at 4 01 34 PM" src="https://github.com/user-attachments/assets/12ea0b07-8249-4536-9836-f3ec2243de8e" />



---
#### Here's what actually got changed :clap:
- Remove the duplicate `csv-importer` service from the `docker-compose.yml` file. 
---
#### Here's how others can test the changes :eyes:
Follow the quick start build script, using the `projects/australia` directory. Verify you are not receiving errors when running the `pelias compose pull` command.