### PR TITLE
allow configuring `ELASTIC_INDEX` for `elastic_stats` command

### DIFF
--- a/cmd/elastic.sh
+++ b/cmd/elastic.sh
@@ -62,7 +62,7 @@ function elastic_info(){ curl -s "http://${ELASTIC_HOST:-localhost:9200}/"; }
 register 'elastic' 'info' 'display elasticsearch version and build info' elastic_info
 
 function elastic_stats(){
-  curl -s "http://${ELASTIC_HOST:-localhost:9200}/pelias/_search?request_cache=true&timeout=10s&pretty=true" \
+  curl -s "http://${ELASTIC_HOST:-localhost:9200}/${ELASTIC_INDEX:-pelias}/_search?request_cache=true&timeout=10s&pretty=true" \
     -H 'Content-Type: application/json' \
     -d '{
           "aggs": {


### PR DESCRIPTION
This PR allows the `indexName` to be configured when executing the `pelias elastic stats` command.

@arnesetzer sorry for all the back-and-forth on this, considering that the scope for this feature is fairly narrow (ie. blue green deployments) I would prefer not to complicate things too much by doing a bunch of refactoring, the `cmd/elastic.sh` script has an established method of overloading the defaults (`ELASTIC_HOST`) so adopting that method allows us to achieve the desired result by simply introducing `ELASTIC_INDEX`.

The ergonomics are maybe not as aesthetically pleasing as using command-line flags, but I don't want to introduce a change where some commands use env vars while others use flags, and this one using a mix of the two.

Again sorry for my poor direction on this, it took me a while to figure out.

closes https://github.com/pelias/docker/issues/371
closes https://github.com/pelias/docker/pull/372
closes https://github.com/pelias/schema/pull/507