### PR TITLE
feat(interpolation): Allow more specific interpolation

### DIFF
--- a/cmd/prepare.sh
+++ b/cmd/prepare.sh
@@ -3,7 +3,7 @@ set -e;
 
 # per-source prepares
 function prepare_polylines(){ compose_run -T 'polylines' bash ./docker_extract.sh; }
-function prepare_interpolation(){ compose_run -T 'interpolation' bash ./docker_build.sh; }
+function prepare_interpolation(){ compose_run -T 'interpolation' bash ./docker_build.sh "$@"; }
 function prepare_placeholder(){
   compose_run -T 'placeholder' ./cmd/extract.sh;
   compose_run -T 'placeholder' ./cmd/build.sh;


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
Counterpart to https://github.com/pelias/interpolation/pull/310. Tl;dr: Allows to specify which data will be used for the interpolation (osm, oa, tiger).

---
#### Here's what actually got changed :clap:
In this PR we only pass all arguments to the docker container.

---
#### Here's how others can test the changes :eyes:

1. Build the docker container for interpolation and run it.
2. Execute pelias prepare interpolation oa => only oa data should be interpolated