### PR TITLE
feat(docker): Remove deprecated version tag in compose

### DIFF
--- a/projects/australia/docker-compose.yml
+++ b/projects/australia/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/austria/docker-compose.yml
+++ b/projects/austria/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/belgium/docker-compose.yml
+++ b/projects/belgium/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/brazil/docker-compose.yml
+++ b/projects/brazil/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/denmark/docker-compose.yml
+++ b/projects/denmark/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/france/docker-compose.yml
+++ b/projects/france/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/germany/docker-compose.yml
+++ b/projects/germany/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/israel/docker-compose.yml
+++ b/projects/israel/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/italy/docker-compose.yml
+++ b/projects/italy/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/jamaica/docker-compose.yml
+++ b/projects/jamaica/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/kyrgyzstan/docker-compose.yml
+++ b/projects/kyrgyzstan/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/las-vegas-metro/docker-compose.yml
+++ b/projects/las-vegas-metro/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/lithuania/docker-compose.yml
+++ b/projects/lithuania/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/los-angeles-metro/docker-compose.yml
+++ b/projects/los-angeles-metro/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/netherlands/docker-compose.yml
+++ b/projects/netherlands/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/new-york-city/docker-compose.yml
+++ b/projects/new-york-city/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/north-america/docker-compose.yml
+++ b/projects/north-america/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/norway/docker-compose.yml
+++ b/projects/norway/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/planet/docker-compose.yml
+++ b/projects/planet/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/poland/docker-compose.yml
+++ b/projects/poland/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/portland-metro/docker-compose.yml
+++ b/projects/portland-metro/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/san-jose-metro/docker-compose.yml
+++ b/projects/san-jose-metro/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/singapore/docker-compose.yml
+++ b/projects/singapore/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/south-africa/docker-compose.yml
+++ b/projects/south-africa/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/south-america/docker-compose.yml
+++ b/projects/south-america/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge

--- a/projects/texas/docker-compose.yml
+++ b/projects/texas/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   default:
     driver: bridge


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.
Closes #382

---
#### Here's the reason for this change :rocket:
Since https://github.com/compose-spec/compose-spec/commit/6d19079ef64dd94d203076e9de6caeb20c498efe the Version tag is obsolete. 

---
#### Here's what actually got changed :clap:
Removes all version tags from all docker-compose.yaml files

